### PR TITLE
Re-enable unit tests on CI and fix ElapsedTimeFromPreviousFrame.

### DIFF
--- a/src/LogicLooper/LogicLooper.cs
+++ b/src/LogicLooper/LogicLooper.cs
@@ -190,7 +190,8 @@ namespace Cysharp.Threading
 
                 lock (_lockActions)
                 {
-                    var elapsedTimeFromPreviousFrame = TimeSpan.FromTicks(begin - lastTimestamp);
+                    var elapsedTicksFromPreviousFrame = (long)((begin - lastTimestamp) * TimestampsToTicks);
+                    var elapsedTimeFromPreviousFrame = TimeSpan.FromTicks(elapsedTicksFromPreviousFrame);
                     lastTimestamp = begin;
 
                     var ctx = new LogicLooperActionContext(this, _frame++, elapsedTimeFromPreviousFrame, _ctsAction.Token);
@@ -307,7 +308,7 @@ namespace Cysharp.Threading
 
         internal readonly struct LooperAction
         {
-            public long BeginAt { get; }
+            public DateTimeOffset BeginAt { get; }
             public object? State { get; }
             public Delegate Action { get; }
             public InternalLogicLooperActionDelegate ActionWrapper { get; }
@@ -315,7 +316,7 @@ namespace Cysharp.Threading
 
             public LooperAction(InternalLogicLooperActionDelegate actionWrapper, Delegate action, object? state)
             {
-                BeginAt = Stopwatch.GetTimestamp();
+                BeginAt = DateTimeOffset.Now;
                 ActionWrapper = actionWrapper ?? throw new ArgumentNullException(nameof(actionWrapper));
                 Action = action ?? throw new ArgumentNullException(nameof(action));
                 State = state;

--- a/test/LogicLooper.Test/LogicLooperTest.cs
+++ b/test/LogicLooper.Test/LogicLooperTest.cs
@@ -10,11 +10,9 @@ namespace LogicLooper.Test
 {
     public class LogicLooperTest
     {
-#if !RUNNING_IN_CI
         [Theory]
         [InlineData(16.6666)] // 60fps
         [InlineData(33.3333)] // 30fps
-#endif
         public async Task TargetFrameTime(double targetFrameTimeMs)
         {
             using var looper = new Cysharp.Threading.LogicLooper(TimeSpan.FromMilliseconds(targetFrameTimeMs));
@@ -52,12 +50,10 @@ namespace LogicLooper.Test
             fps.Should().BeInRange(looper.TargetFrameRate - 2, looper.TargetFrameRate + 2);
         }
 
-#if !RUNNING_IN_CI
         [Theory]
         [InlineData(60)]
         [InlineData(30)]
         [InlineData(20)]
-#endif
         public async Task TargetFrameRate_1(int targetFps)
         {
             using var looper = new Cysharp.Threading.LogicLooper(targetFps);
@@ -204,9 +200,7 @@ namespace LogicLooper.Test
         }
 
 
-#if !RUNNING_IN_CI
         [Fact]
-#endif
         public async Task LastProcessingDuration()
         {
             using var looper = new Cysharp.Threading.LogicLooper(60);

--- a/test/LogicLooper.Test/LogicLooperTest.cs
+++ b/test/LogicLooper.Test/LogicLooperTest.cs
@@ -20,14 +20,14 @@ namespace LogicLooper.Test
             looper.ApproximatelyRunningActions.Should().Be(0);
             looper.TargetFrameRate.Should().Be(1000 / (double)targetFrameTimeMs);
 
-            var beginTimestamp = Stopwatch.GetTimestamp();
+            var beginTimestamp = DateTime.Now.Ticks;
             var lastTimestamp = beginTimestamp;
             var fps = 0d;
             var task = looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
             {
-                var now = Stopwatch.GetTimestamp();
-                var elapsedFromBeginMilliseconds = (now - beginTimestamp) / 10000d;
-                var elapsedFromPreviousFrameMilliseconds = (now - lastTimestamp) / 10000d;
+                var now = DateTime.Now.Ticks;
+                var elapsedFromBeginMilliseconds = (now - beginTimestamp) / TimeSpan.TicksPerMillisecond;
+                var elapsedFromPreviousFrameMilliseconds = (now - lastTimestamp) / TimeSpan.TicksPerMillisecond;
 
                 fps = (fps == 0) ? (1000 / elapsedFromPreviousFrameMilliseconds) : (fps + (1000 / elapsedFromPreviousFrameMilliseconds)) / 2d;
 
@@ -37,13 +37,13 @@ namespace LogicLooper.Test
             });
 
             // wait for moving action from queue to actions.
-            await Task.Delay(100);
+            await Task.Delay(300);
 
             looper.ApproximatelyRunningActions.Should().Be(1);
 
             await task;
 
-            await Task.Delay(100);
+            await Task.Delay(300);
 
             looper.ApproximatelyRunningActions.Should().Be(0);
 
@@ -61,14 +61,14 @@ namespace LogicLooper.Test
             looper.ApproximatelyRunningActions.Should().Be(0);
             ((int)looper.TargetFrameRate).Should().Be(targetFps);
 
-            var beginTimestamp = Stopwatch.GetTimestamp();
+            var beginTimestamp = DateTime.Now.Ticks;
             var lastTimestamp = beginTimestamp;
             var fps = 0d;
             var task = looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
             {
-                var now = Stopwatch.GetTimestamp();
-                var elapsedFromBeginMilliseconds = (now - beginTimestamp) / 10000d;
-                var elapsedFromPreviousFrameMilliseconds = (now - lastTimestamp) / 10000d;
+                var now = DateTime.Now.Ticks;
+                var elapsedFromBeginMilliseconds = (now - beginTimestamp) / TimeSpan.TicksPerMillisecond;
+                var elapsedFromPreviousFrameMilliseconds = (now - lastTimestamp) / TimeSpan.TicksPerMillisecond;
 
                 fps = (fps == 0) ? (1000 / elapsedFromPreviousFrameMilliseconds) : (fps + (1000 / elapsedFromPreviousFrameMilliseconds)) / 2d;
 
@@ -78,13 +78,13 @@ namespace LogicLooper.Test
             });
 
             // wait for moving action from queue to actions.
-            await Task.Delay(100);
+            await Task.Delay(300);
 
             looper.ApproximatelyRunningActions.Should().Be(1);
 
             await task;
 
-            await Task.Delay(100);
+            await Task.Delay(300);
 
             looper.ApproximatelyRunningActions.Should().Be(0);
 

--- a/test/LogicLooper.Test/LogicLooperTest.cs
+++ b/test/LogicLooper.Test/LogicLooperTest.cs
@@ -29,7 +29,9 @@ namespace LogicLooper.Test
                 var elapsedFromBeginMilliseconds = (now - beginTimestamp) / TimeSpan.TicksPerMillisecond;
                 var elapsedFromPreviousFrameMilliseconds = (now - lastTimestamp) / TimeSpan.TicksPerMillisecond;
 
-                fps = (fps == 0) ? (1000 / elapsedFromPreviousFrameMilliseconds) : (fps + (1000 / elapsedFromPreviousFrameMilliseconds)) / 2d;
+                if (elapsedFromPreviousFrameMilliseconds == 0) return true;
+
+                fps = (fps + (1000 / elapsedFromPreviousFrameMilliseconds)) / 2d;
 
                 lastTimestamp = now;
 
@@ -37,13 +39,13 @@ namespace LogicLooper.Test
             });
 
             // wait for moving action from queue to actions.
-            await Task.Delay(300);
+            await Task.Delay(100);
 
             looper.ApproximatelyRunningActions.Should().Be(1);
 
             await task;
 
-            await Task.Delay(300);
+            await Task.Delay(100);
 
             looper.ApproximatelyRunningActions.Should().Be(0);
 
@@ -70,7 +72,9 @@ namespace LogicLooper.Test
                 var elapsedFromBeginMilliseconds = (now - beginTimestamp) / TimeSpan.TicksPerMillisecond;
                 var elapsedFromPreviousFrameMilliseconds = (now - lastTimestamp) / TimeSpan.TicksPerMillisecond;
 
-                fps = (fps == 0) ? (1000 / elapsedFromPreviousFrameMilliseconds) : (fps + (1000 / elapsedFromPreviousFrameMilliseconds)) / 2d;
+                if (elapsedFromPreviousFrameMilliseconds == 0) return true;
+
+                fps = (fps + (1000 / elapsedFromPreviousFrameMilliseconds)) / 2d;
 
                 lastTimestamp = now;
 
@@ -78,13 +82,13 @@ namespace LogicLooper.Test
             });
 
             // wait for moving action from queue to actions.
-            await Task.Delay(300);
+            await Task.Delay(100);
 
             looper.ApproximatelyRunningActions.Should().Be(1);
 
             await task;
 
-            await Task.Delay(300);
+            await Task.Delay(100);
 
             looper.ApproximatelyRunningActions.Should().Be(0);
 


### PR DESCRIPTION
This PR re-enables unit tests on Continuous Integration and fixes that `ElapsedTimeFromPreviousFrame` returns an incorrect value (ref #2).