### PR TITLE
Update TargetFrameworks

### DIFF
--- a/LogicLooper.sln
+++ b/LogicLooper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29728.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31808.319
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogicLooper", "src\LogicLooper\LogicLooper.csproj", "{E3B6DA2C-B592-44C9-8DD9-F6D3437B338D}"
 EndProject
@@ -11,7 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
-		.circleci\config.yml = .circleci\config.yml
+		.github\workflows\build-master.yaml = .github\workflows\build-master.yaml
+		.github\workflows\build-release.yml = .github\workflows\build-release.yml
 		Directory.Build.props = Directory.Build.props
 		README.ja.md = README.ja.md
 		README.md = README.md

--- a/src/LogicLooper/LogicLooper.csproj
+++ b/src/LogicLooper/LogicLooper.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <RootNamespace>Cysharp.Threading</RootNamespace>
     <AssemblyName>Cysharp.Threading.LogicLooper</AssemblyName>
     <nullable>enable</nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>opensource.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
 
     <!-- NuGet Package information -->
     <PackageId>LogicLooper</PackageId>
@@ -18,7 +19,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
   </ItemGroup>
 </Project>

--- a/src/LogicLooper/LogicLooperCoroutine.cs
+++ b/src/LogicLooper/LogicLooperCoroutine.cs
@@ -101,9 +101,9 @@ namespace Cysharp.Threading
     [AsyncMethodBuilder(typeof(LogicLooperCoroutineAsyncValueTaskMethodBuilder<>))]
     public sealed class LogicLooperCoroutine<TResult> : LogicLooperCoroutine
     {
-        private TResult _result;
+        private TResult? _result;
 
-        public TResult Result
+        public TResult? Result
         {
             get
             {

--- a/test/LogicLooper.Test/LogicLooper.Test.csproj
+++ b/test/LogicLooper.Test/LogicLooper.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <NoWarn>1998</NoWarn>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/test/LogicLooper.Test/LogicLooperCoroutineTest.cs
+++ b/test/LogicLooper.Test/LogicLooperCoroutineTest.cs
@@ -154,7 +154,9 @@ namespace LogicLooper.Test
 
                         throw new Exception("ThrownFromCoroutine");
 
+#pragma warning disable CS0162 // Unreachable code detected
                         return 1;
+#pragma warning restore CS0162 // Unreachable code detected
                     });
                 }
 


### PR DESCRIPTION
LogicLooper now targets .NET 5, .NET Standard 2.1 and .NET Standard 2.0.