### PR TITLE
Add experimental support for async-aware loop action

### DIFF
--- a/src/LogicLooper/ILogicLooper.cs
+++ b/src/LogicLooper/ILogicLooper.cs
@@ -41,6 +41,23 @@ public interface ILogicLooper : IDisposable
     Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state);
 
     /// <summary>
+    /// [Experimental] Registers a loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
+    /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction);
+
+    /// <summary>
+    /// [Experimental] Registers a loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
+    /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state);
+
+    /// <summary>
     /// Stops the action loop of the looper.
     /// </summary>
     /// <param name="shutdownDelay"></param>

--- a/src/LogicLooper/ILogicLooperPool.cs
+++ b/src/LogicLooper/ILogicLooperPool.cs
@@ -8,19 +8,36 @@ public interface ILogicLooperPool : IDisposable
     IReadOnlyList<ILogicLooper> Loopers { get; }
 
     /// <summary>
-    /// Registers an loop-frame action to a pooled looper and returns <see cref="Task"/> to wait for completion.
+    /// Registers a loop-frame action to a pooled looper and returns <see cref="Task"/> to wait for completion.
     /// </summary>
     /// <param name="loopAction"></param>
     /// <returns></returns>
     Task RegisterActionAsync(LogicLooperActionDelegate loopAction);
 
     /// <summary>
-    /// Registers an loop-frame action with state object to a pooled looper and returns <see cref="Task"/> to wait for completion.
+    /// Registers a loop-frame action with state object to a pooled looper and returns <see cref="Task"/> to wait for completion.
     /// </summary>
     /// <param name="loopAction"></param>
     /// <param name="state"></param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state);
+
+    /// <summary>
+    /// [Experimental] Registers an async-aware loop-frame action to a pooled looper and returns <see cref="Task"/> to wait for completion.
+    /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction);
+
+    /// <summary>
+    /// [Experimental] Registers an async-aware loop-frame action with state object to a pooled looper and returns <see cref="Task"/> to wait for completion.
+    /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state);
 
     /// <summary>
     /// Stops all action loop of the loopers.

--- a/src/LogicLooper/Internal/LogicLooperSynchronizationContext.cs
+++ b/src/LogicLooper/Internal/LogicLooperSynchronizationContext.cs
@@ -1,0 +1,40 @@
+using System.Collections.Concurrent;
+
+namespace Cysharp.Threading.Internal;
+
+internal class LogicLooperSynchronizationContext : SynchronizationContext, IDisposable
+{
+    private readonly Task _loopTask;
+    private readonly ConcurrentQueue<(SendOrPostCallback Callback, object? State)> _queue;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+
+    public LogicLooperSynchronizationContext(ILogicLooper logicLooper)
+    {
+        _cancellationTokenSource = new CancellationTokenSource();
+        _queue = new ConcurrentQueue<(SendOrPostCallback Callback, object? State)>();
+        _loopTask = logicLooper.RegisterActionAsync((in LogicLooperActionContext ctx, CancellationToken cancellationToken) =>
+        {
+            while (_queue.TryDequeue(out var action))
+            {
+                action.Callback(action.State);
+            }
+
+            return !cancellationToken.IsCancellationRequested;
+        }, _cancellationTokenSource.Token);
+    }
+
+    public override void Post(SendOrPostCallback d, object? state)
+    {
+        _queue.Enqueue((d, state));
+    }
+
+    public override void Send(SendOrPostCallback d, object? state)
+    {
+        throw new NotSupportedException();
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+    }
+}

--- a/src/LogicLooper/Internal/LogicLooperSynchronizationContext.cs
+++ b/src/LogicLooper/Internal/LogicLooperSynchronizationContext.cs
@@ -1,18 +1,40 @@
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 namespace Cysharp.Threading.Internal;
 
 internal class LogicLooperSynchronizationContext : SynchronizationContext, IDisposable
 {
-    private readonly Task _loopTask;
+    private readonly ILogicLooper _logicLooper;
     private readonly ConcurrentQueue<(SendOrPostCallback Callback, object? State)> _queue;
     private readonly CancellationTokenSource _cancellationTokenSource;
+
+    private int _initialized;
+    private Task? _loopTask;
 
     public LogicLooperSynchronizationContext(ILogicLooper logicLooper)
     {
         _cancellationTokenSource = new CancellationTokenSource();
         _queue = new ConcurrentQueue<(SendOrPostCallback Callback, object? State)>();
-        _loopTask = logicLooper.RegisterActionAsync((in LogicLooperActionContext ctx, CancellationToken cancellationToken) =>
+        _logicLooper = logicLooper;
+        
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureRunDequeueLoop()
+    {
+        if (Interlocked.CompareExchange(ref _initialized, 1, 0) != 0) return; // the dequeue loop has already started.
+        StartDequeueLoop();
+    }
+
+    private void StartDequeueLoop()
+    {
+        if (_loopTask != null)
+        {
+            throw new InvalidOperationException("The dequeue loop has already started.");
+        }
+
+        _loopTask = _logicLooper.RegisterActionAsync((in LogicLooperActionContext ctx, CancellationToken cancellationToken) =>
         {
             while (_queue.TryDequeue(out var action))
             {
@@ -25,6 +47,8 @@ internal class LogicLooperSynchronizationContext : SynchronizationContext, IDisp
 
     public override void Post(SendOrPostCallback d, object? state)
     {
+        EnsureRunDequeueLoop();
+
         _queue.Enqueue((d, state));
     }
 

--- a/src/LogicLooper/Internal/NotInitializedLogicLooperPool.cs
+++ b/src/LogicLooper/Internal/NotInitializedLogicLooperPool.cs
@@ -10,6 +10,12 @@ internal class NotInitializedLogicLooperPool : ILogicLooperPool
     public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state)
         => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
 
+    public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
+        => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
+
+    public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
+        => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
+
     public Task ShutdownAsync(TimeSpan shutdownDelay)
         => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
 

--- a/src/LogicLooper/LogicLooper.csproj
+++ b/src/LogicLooper/LogicLooper.csproj
@@ -32,4 +32,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="LogicLooper.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f1ee449290a81377cf1a6d598f10a3e2de6c45ee5377140b179b7a2260007c4ba633a6f766a0b3392ae2160819d625d9d9d65a134b722fd4e637793479d6c8d72490f9992293ee53933205620245e55fcddb7ce6395d72c94365a432808fbcf1bf8ff2932a1263715f8bc73bb25b96366f118c58e24da5f2bee32223948d7bc5" />
+  </ItemGroup>
 </Project>

--- a/src/LogicLooper/LogicLooperPool.cs
+++ b/src/LogicLooper/LogicLooperPool.cs
@@ -48,6 +48,14 @@ public sealed partial class LogicLooperPool : ILogicLooperPool, IDisposable
         => _balancer.GetPooledLooper(_loopers).RegisterActionAsync(loopAction, state);
 
     /// <inheritdoc />
+    public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
+        => _balancer.GetPooledLooper(_loopers).RegisterActionAsync(loopAction);
+
+    /// <inheritdoc />
+    public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
+        => _balancer.GetPooledLooper(_loopers).RegisterActionAsync(loopAction, state);
+
+    /// <inheritdoc />
     public async Task ShutdownAsync(TimeSpan shutdownDelay)
     {
         await Task.WhenAll(_loopers.Select(x => x.ShutdownAsync(shutdownDelay)));

--- a/src/LogicLooper/ManualLogicLooper.cs
+++ b/src/LogicLooper/ManualLogicLooper.cs
@@ -57,7 +57,7 @@ public sealed class ManualLogicLooper : ILogicLooper
         var completed = new List<LogicLooper.LooperAction>();
         lock (_actions)
         {
-            foreach (var action in _actions)
+            foreach (var action in _actions.ToArray())
             {
                 if (!InvokeAction(ctx, action))
                 {

--- a/src/LogicLooper/ManualLogicLooper.cs
+++ b/src/LogicLooper/ManualLogicLooper.cs
@@ -106,6 +106,28 @@ public sealed class ManualLogicLooper : ILogicLooper
         }
         return action.Future.Task;
     }
+    
+    /// <inheritdoc />
+    public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
+    {
+        var action = new LogicLooper.LooperAction(LogicLooper.DelegateHelper.GetWrapper(), LogicLooper.DelegateHelper.ConvertAsyncToSync(loopAction), default);
+        lock (_actions)
+        {
+            _actions.Add(action);
+        }
+        return action.Future.Task;
+    }
+
+    /// <inheritdoc />
+    public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
+    {
+        var action = new LogicLooper.LooperAction(LogicLooper.DelegateHelper.GetWrapper<TState>(), LogicLooper.DelegateHelper.ConvertAsyncToSync(loopAction), state);
+        lock (_actions)
+        {
+            _actions.Add(action);
+        }
+        return action.Future.Task;
+    }
 
     /// <inheritdoc />
     public Task ShutdownAsync(TimeSpan shutdownDelay)

--- a/src/LogicLooper/ManualLogicLooperPool.cs
+++ b/src/LogicLooper/ManualLogicLooperPool.cs
@@ -60,6 +60,18 @@ public sealed class ManualLogicLooperPool : ILogicLooperPool
     }
 
     /// <inheritdoc />
+    public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
+    {
+        return Loopers[0].RegisterActionAsync(loopAction);
+    }
+
+    /// <inheritdoc />
+    public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
+    {
+        return Loopers[0].RegisterActionAsync(loopAction, state);
+    }
+
+    /// <inheritdoc />
     public Task ShutdownAsync(TimeSpan shutdownDelay)
     {
         return Loopers[0].ShutdownAsync(shutdownDelay);

--- a/test/LogicLooper.Test/LogicLooperSynchronizationContextTest.cs
+++ b/test/LogicLooper.Test/LogicLooperSynchronizationContextTest.cs
@@ -1,0 +1,66 @@
+using Cysharp.Threading;
+using Cysharp.Threading.Internal;
+
+namespace LogicLooper.Test;
+
+public class LogicLooperSynchronizationContextTest
+{
+    [Fact]
+    public async Task Post()
+    {
+        using var looper = new ManualLogicLooper(60);
+        using var syncContext = new LogicLooperSynchronizationContext(looper);
+
+        var count = 0;
+        syncContext.Post(_ =>
+        {
+            count++;
+        }, null);
+        syncContext.Post(_ =>
+        {
+            count++;
+        }, null);
+        syncContext.Post(_ =>
+        {
+            count++;
+        }, null);
+
+        count.Should().Be(0);
+        looper.Tick();
+        count.Should().Be(3);
+        looper.Tick();
+        count.Should().Be(3);
+        syncContext.Post(_ =>
+        {
+            count++;
+        }, null);
+        looper.Tick();
+        count.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task LooperIntegration()
+    {
+        using var looper = new ManualLogicLooper(60);
+        using var syncContext = new LogicLooperSynchronizationContext(looper);
+
+        var result = new List<string>();
+        var task = looper.RegisterActionAsync(async (ctx) =>
+        {
+            result.Add("1"); // Frame: 1
+            await Task.Delay(250);
+            result.Add("2"); // Frame: 2
+            return false;
+        });
+
+        looper.Tick();
+        result.Should().BeEquivalentTo(new[] { "1" });
+
+        await Task.Delay(500);
+
+        looper.Tick();
+        result.Should().BeEquivalentTo(new[] { "1", "2" });
+
+        task.IsCompleted.Should().BeTrue();
+    }
+}

--- a/test/LogicLooper.Test/LogicLooperSynchronizationContextTest.cs
+++ b/test/LogicLooper.Test/LogicLooperSynchronizationContextTest.cs
@@ -43,7 +43,7 @@ public class LogicLooperSynchronizationContextTest
     {
         using var looper = new ManualLogicLooper(60);
         using var syncContext = new LogicLooperSynchronizationContext(looper);
-        SynchronizationContext.SetSynchronizationContext(syncContext);
+        SynchronizationContext.SetSynchronizationContext(syncContext); // This context is used when advancing frame within the Tick method. Use `ConfigureAwait(false)` in the following codes.
 
         var result = new List<string>();
         var task = looper.RegisterActionAsync(async (ctx) =>
@@ -57,9 +57,10 @@ public class LogicLooperSynchronizationContextTest
         looper.Tick();
         result.Should().BeEquivalentTo(new[] { "1" });
 
-        await Task.Delay(500);
+        await Task.Delay(500).ConfigureAwait(false);
 
-        looper.Tick();
+        looper.Tick(); // Run continuation
+        looper.Tick(); // Wait for complete action
         result.Should().BeEquivalentTo(new[] { "1", "2" });
 
         task.IsCompleted.Should().BeTrue();
@@ -70,7 +71,7 @@ public class LogicLooperSynchronizationContextTest
     {
         using var looper = new ManualLogicLooper(60);
         using var syncContext = new LogicLooperSynchronizationContext(looper);
-        SynchronizationContext.SetSynchronizationContext(syncContext); // This context is used when advancing frame within the Tick method.
+        SynchronizationContext.SetSynchronizationContext(syncContext); // This context is used when advancing frame within the Tick method. Use `ConfigureAwait(false)` in the following codes.
         var t = looper.RegisterActionAsync((in LogicLooperActionContext ctx) => false);
 
         looper.ApproximatelyRunningActions.Should().Be(1);
@@ -84,7 +85,7 @@ public class LogicLooperSynchronizationContextTest
     {
         using var looper = new ManualLogicLooper(60);
         using var syncContext = new LogicLooperSynchronizationContext(looper);
-        SynchronizationContext.SetSynchronizationContext(syncContext); // This context is used when advancing frame within the Tick method.
+        SynchronizationContext.SetSynchronizationContext(syncContext); // This context is used when advancing frame within the Tick method. Use `ConfigureAwait(false)` in the following codes.
         var t = looper.RegisterActionAsync(async (LogicLooperActionContext ctx) =>
         {
             await Task.Yield();


### PR DESCRIPTION
Adds experimental support for loop actions that can await asynchronous events.

With SynchronizationContext, all asynchronous continuations are executed on the loop thread.
Please beware that asynchronous actions are executed across multiple frames, unlike synchronous actions.

```csharp
await looper.RegisterActionAsync(static async (ctx, state) =>
{
    state.Add("1"); // Frame: 1
    await Task.Delay(250);
    state.Add("2"); // Frame: 2 or later
    return false;
});
```