### PR TITLE
Add GetLooper API

### DIFF
--- a/src/LogicLooper/ILogicLooper.cs
+++ b/src/LogicLooper/ILogicLooper.cs
@@ -41,7 +41,7 @@ public interface ILogicLooper : IDisposable
     Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state);
 
     /// <summary>
-    /// [Experimental] Registers a loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
+    /// [Experimental] Registers an async-aware loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
     /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
     /// </summary>
     /// <param name="loopAction"></param>
@@ -49,7 +49,7 @@ public interface ILogicLooper : IDisposable
     Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction);
 
     /// <summary>
-    /// [Experimental] Registers a loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
+    /// [Experimental] Registers an async-aware  loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
     /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
     /// </summary>
     /// <param name="loopAction"></param>

--- a/src/LogicLooper/ILogicLooperPool.cs
+++ b/src/LogicLooper/ILogicLooperPool.cs
@@ -45,4 +45,10 @@ public interface ILogicLooperPool : IDisposable
     /// <param name="shutdownDelay"></param>
     /// <returns></returns>
     Task ShutdownAsync(TimeSpan shutdownDelay);
+
+    /// <summary>
+    /// Gets a <see cref="ILogicLooper"/> instance from the pool. This is useful when you want to explicitly register multiple actions on the same loop thread.
+    /// </summary>
+    /// <returns></returns>
+    ILogicLooper GetLooper();
 }

--- a/src/LogicLooper/Internal/NotInitializedLogicLooperPool.cs
+++ b/src/LogicLooper/Internal/NotInitializedLogicLooperPool.cs
@@ -19,5 +19,8 @@ internal class NotInitializedLogicLooperPool : ILogicLooperPool
     public Task ShutdownAsync(TimeSpan shutdownDelay)
         => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
 
+    public ILogicLooper GetLooper()
+        => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
+
     public void Dispose() { }
 }

--- a/src/LogicLooper/LogicLooperPool.cs
+++ b/src/LogicLooper/LogicLooperPool.cs
@@ -41,25 +41,29 @@ public sealed partial class LogicLooperPool : ILogicLooperPool, IDisposable
 
     /// <inheritdoc />
     public Task RegisterActionAsync(LogicLooperActionDelegate loopAction)
-        => _balancer.GetPooledLooper(_loopers).RegisterActionAsync(loopAction);
+        => GetLooper().RegisterActionAsync(loopAction);
 
     /// <inheritdoc />
     public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state)
-        => _balancer.GetPooledLooper(_loopers).RegisterActionAsync(loopAction, state);
+        => GetLooper().RegisterActionAsync(loopAction, state);
 
     /// <inheritdoc />
     public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
-        => _balancer.GetPooledLooper(_loopers).RegisterActionAsync(loopAction);
+        => GetLooper().RegisterActionAsync(loopAction);
 
     /// <inheritdoc />
     public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
-        => _balancer.GetPooledLooper(_loopers).RegisterActionAsync(loopAction, state);
+        => GetLooper().RegisterActionAsync(loopAction, state);
 
     /// <inheritdoc />
     public async Task ShutdownAsync(TimeSpan shutdownDelay)
     {
         await Task.WhenAll(_loopers.Select(x => x.ShutdownAsync(shutdownDelay)));
     }
+
+    /// <inheritdoc />
+    public ILogicLooper GetLooper()
+        => _balancer.GetPooledLooper(_loopers);
 
     public void Dispose()
     {

--- a/src/LogicLooper/ManualLogicLooperPool.cs
+++ b/src/LogicLooper/ManualLogicLooperPool.cs
@@ -43,37 +43,29 @@ public sealed class ManualLogicLooperPool : ILogicLooperPool
 
     /// <inheritdoc />
     public void Dispose()
-    {
-        Loopers[0].Dispose();
-    }
+        => Loopers[0].Dispose();
 
     /// <inheritdoc />
     public Task RegisterActionAsync(LogicLooperActionDelegate loopAction)
-    {
-        return Loopers[0].RegisterActionAsync(loopAction);
-    }
+        => Loopers[0].RegisterActionAsync(loopAction);
 
     /// <inheritdoc />
     public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state)
-    {
-        return Loopers[0].RegisterActionAsync(loopAction, state);
-    }
+        => Loopers[0].RegisterActionAsync(loopAction, state);
 
     /// <inheritdoc />
     public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
-    {
-        return Loopers[0].RegisterActionAsync(loopAction);
-    }
+        => Loopers[0].RegisterActionAsync(loopAction);
 
     /// <inheritdoc />
     public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
-    {
-        return Loopers[0].RegisterActionAsync(loopAction, state);
-    }
+        => Loopers[0].RegisterActionAsync(loopAction, state);
 
     /// <inheritdoc />
     public Task ShutdownAsync(TimeSpan shutdownDelay)
-    {
-        return Loopers[0].ShutdownAsync(shutdownDelay);
-    }
+        => Loopers[0].ShutdownAsync(shutdownDelay);
+
+    /// <inheritdoc />
+    public ILogicLooper GetLooper()
+        => Loopers[0];
 }

--- a/test/LogicLooper.Test/LogicLooperPoolTest.cs
+++ b/test/LogicLooper.Test/LogicLooperPoolTest.cs
@@ -43,4 +43,24 @@ public class LogicLooperPoolTest
 
         executedCount.Should().Be(actionCount * loopCount);
     }
+
+    [Fact]
+    public void GetLooper()
+    {
+        using var pool = new LogicLooperPool(60, 4, new FakeSequentialLogicLooperPoolBalancer());
+        pool.GetLooper().Should().Be(pool.Loopers[0]);
+        pool.GetLooper().Should().Be(pool.Loopers[1]);
+        pool.GetLooper().Should().Be(pool.Loopers[2]);
+        pool.GetLooper().Should().Be(pool.Loopers[3]);
+        pool.GetLooper().Should().Be(pool.Loopers[0]);
+    }
+
+    class FakeSequentialLogicLooperPoolBalancer : ILogicLooperPoolBalancer
+    {
+        private int _count;
+        public Cysharp.Threading.LogicLooper GetPooledLooper(Cysharp.Threading.LogicLooper[] pooledLoopers)
+        {
+            return pooledLoopers[_count++ % pooledLoopers.Length];
+        }
+    }
 }

--- a/test/LogicLooper.Test/ManualLogicLooperPoolTest.cs
+++ b/test/LogicLooper.Test/ManualLogicLooperPoolTest.cs
@@ -26,4 +26,13 @@ public class ManualLogicLooperPoolTest
         pool.Loopers[0].ApproximatelyRunningActions.Should().Be(0);
         t1.IsCompletedSuccessfully.Should().BeTrue();
     }
+
+    [Fact]
+    public void GetLooper()
+    {
+        var pool = new ManualLogicLooperPool(60.0);
+        var looper = pool.GetLooper();
+
+        looper.Should().Be(pool.FakeLooper);
+    }
 }


### PR DESCRIPTION
This PR adds an API to retrieve LogicLooper instance from the pool.
This is useful when you want to explicitly register multiple actions on the same loop thread.

```csharp
var logicLooper = LogicLooper.Shared.GetLooper();

var t1 = logicLooper.RegisterActionAsync((in LogicLooperActionContext ctx) => {/* ... */});

// This action will be executed on the same thread as t1.
var t2 = logicLooper.RegisterActionAsync((in LogicLooperActionContext ctx) => {/* ... */});
```