### PR TITLE
Make possible to override the target fps for each loop action.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# IntelliJ IDEA / Rider
+.idea/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ await looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
 - [Advanced](#advanced)
   - [Unit tests / Frame-by-Frame execution](#unit-tests--frame-by-frame-execution)
   - [Coroutine](#coroutine)
+  - [TargetFrameRateOverride](#targetframerateoverride)
 - [Experimental](#experimental)
   - [async-aware loop actions](#async-aware-loop-actions)
 
@@ -178,6 +179,30 @@ await looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
     return true;
 });
 ```
+
+### TargetFrameRateOverride
+
+`TargetFrameRateOverride` option allows to override the frame rate for each action. This can be useful in cases where you want to mix multiple frame rates, such as expecting the main loop to run at 30fps, but wanting some actions to be called at 5fps.
+
+You can also set the frame rate for each Looper that executes the loops, but the design of LogicLooper is 1-loop per thread, so in principle we expect a number of Loopers in accordance with the number of cores. By setting the frame rate for each action, you can keep the number of Loopers fixed even if the workload changes.
+
+```csharp
+using var looper = new LogicLooper(60); // 60 fps
+
+await looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
+{
+    // Something to do ...
+    return true;
+}); // The action will be called at 60fps.
+
+await looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
+{
+    // Something to do (low priority) ...
+    return true;
+}, LoopActionOptions.Default with { TargetFrameRateOverride = 10 }); // The action will be called at 10fps.
+```
+
+The granularity of action execution changes based on the execution frequency of the main loop itself. This means that the accuracy may be inferior to the target frame rate of the Looper.
 
 ## Experimental
 ### async-aware loop actions

--- a/README.md
+++ b/README.md
@@ -176,3 +176,23 @@ await looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
     return true;
 });
 ```
+
+## Experimental
+### async-aware loop actions
+Experimental support for loop actions that can await asynchronous events.
+
+With SynchronizationContext, all asynchronous continuations are executed on the loop thread.
+Please beware that asynchronous actions are executed across multiple frames, unlike synchronous actions.
+
+```csharp
+await looper.RegisterActionAsync(static async (ctx, state) =>
+{
+    state.Add("1"); // Frame: 1
+    await Task.Delay(250);
+    state.Add("2"); // Frame: 2 or later
+    return false;
+});
+```
+
+> [!WARNING]
+> If an action completes immediately (`ValueTask.IsCompleted = true`), there's no performance difference from non-async version. But it is very slow if there's a need to await. This asynchronous support provides as an emergency hatch when it becomes necessary to communicate with the outside at a low frequency. We do not recommended to perform asynchronous processing at a high frequency.

--- a/src/LogicLooper/ILogicLooper.cs
+++ b/src/LogicLooper/ILogicLooper.cs
@@ -33,12 +33,29 @@ public interface ILogicLooper : IDisposable
     Task RegisterActionAsync(LogicLooperActionDelegate loopAction);
 
     /// <summary>
+    /// Registers a loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync(LogicLooperActionDelegate loopAction, LooperActionOptions options);
+
+    /// <summary>
     /// Registers a loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
     /// </summary>
     /// <param name="loopAction"></param>
     /// <param name="state"></param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state);
+
+    /// <summary>
+    /// Registers a loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="state"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options);
 
     /// <summary>
     /// [Experimental] Registers an async-aware loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
@@ -49,6 +66,15 @@ public interface ILogicLooper : IDisposable
     Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction);
 
     /// <summary>
+    /// [Experimental] Registers an async-aware loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
+    /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction, LooperActionOptions options);
+
+    /// <summary>
     /// [Experimental] Registers an async-aware  loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
     /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
     /// </summary>
@@ -56,6 +82,15 @@ public interface ILogicLooper : IDisposable
     /// <param name="state"></param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state);
+
+    /// <summary>
+    /// [Experimental] Registers an async-aware  loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
+    /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options);
 
     /// <summary>
     /// Stops the action loop of the looper.

--- a/src/LogicLooper/ILogicLooper.cs
+++ b/src/LogicLooper/ILogicLooper.cs
@@ -28,32 +28,32 @@ public interface ILogicLooper : IDisposable
     /// <summary>
     /// Registers a loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
     /// </summary>
-    /// <param name="loopAction"></param>
+    /// <param name="loopAction">The action that is called every frame in the loop.</param>
     /// <returns></returns>
     Task RegisterActionAsync(LogicLooperActionDelegate loopAction);
 
     /// <summary>
     /// Registers a loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
     /// </summary>
-    /// <param name="loopAction"></param>
-    /// <param name="options"></param>
+    /// <param name="loopAction">The action that is called every frame in the loop.</param>
+    /// <param name="options">The options of the loop action.</param>
     /// <returns></returns>
     Task RegisterActionAsync(LogicLooperActionDelegate loopAction, LooperActionOptions options);
 
     /// <summary>
     /// Registers a loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
     /// </summary>
-    /// <param name="loopAction"></param>
-    /// <param name="state"></param>
+    /// <param name="loopAction">The action that is called every frame in the loop.</param>
+    /// <param name="state">The object pass to the loop action.</param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state);
 
     /// <summary>
     /// Registers a loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
     /// </summary>
-    /// <param name="loopAction"></param>
-    /// <param name="state"></param>
-    /// <param name="options"></param>
+    /// <param name="loopAction">The action that is called every frame in the loop.</param>
+    /// <param name="state">The object pass to the loop action.</param>
+    /// <param name="options">The options of the loop action.</param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options);
 
@@ -61,7 +61,7 @@ public interface ILogicLooper : IDisposable
     /// [Experimental] Registers an async-aware loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
     /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
     /// </summary>
-    /// <param name="loopAction"></param>
+    /// <param name="loopAction">The action that is called every frame in the loop.</param>
     /// <returns></returns>
     Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction);
 
@@ -69,26 +69,27 @@ public interface ILogicLooper : IDisposable
     /// [Experimental] Registers an async-aware loop-frame action to the looper and returns <see cref="Task"/> to wait for completion.
     /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
     /// </summary>
-    /// <param name="loopAction"></param>
-    /// <param name="options"></param>
+    /// <param name="loopAction">The action that is called every frame in the loop.</param>
+    /// <param name="options">The options of the loop action.</param>
     /// <returns></returns>
     Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction, LooperActionOptions options);
 
     /// <summary>
-    /// [Experimental] Registers an async-aware  loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
+    /// [Experimental] Registers an async-aware loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
     /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
     /// </summary>
-    /// <param name="loopAction"></param>
-    /// <param name="state"></param>
+    /// <param name="loopAction">The action that is called every frame in the loop.</param>
+    /// <param name="state">The object pass to the loop action.</param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state);
 
     /// <summary>
-    /// [Experimental] Registers an async-aware  loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
+    /// [Experimental] Registers an async-aware loop-frame action with state object to the looper and returns <see cref="Task"/> to wait for completion.
     /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
     /// </summary>
-    /// <param name="loopAction"></param>
-    /// <param name="state"></param>
+    /// <param name="loopAction">The action that is called every frame in the loop.</param>
+    /// <param name="state">The object pass to the loop action.</param>
+    /// <param name="options">The options of the loop action.</param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options);
 

--- a/src/LogicLooper/ILogicLooperPool.cs
+++ b/src/LogicLooper/ILogicLooperPool.cs
@@ -15,12 +15,29 @@ public interface ILogicLooperPool : IDisposable
     Task RegisterActionAsync(LogicLooperActionDelegate loopAction);
 
     /// <summary>
+    /// Registers a loop-frame action to a pooled looper and returns <see cref="Task"/> to wait for completion.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync(LogicLooperActionDelegate loopAction, LooperActionOptions options);
+
+    /// <summary>
     /// Registers a loop-frame action with state object to a pooled looper and returns <see cref="Task"/> to wait for completion.
     /// </summary>
     /// <param name="loopAction"></param>
     /// <param name="state"></param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state);
+
+    /// <summary>
+    /// Registers a loop-frame action with state object to a pooled looper and returns <see cref="Task"/> to wait for completion.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="state"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options);
 
     /// <summary>
     /// [Experimental] Registers an async-aware loop-frame action to a pooled looper and returns <see cref="Task"/> to wait for completion.
@@ -31,6 +48,15 @@ public interface ILogicLooperPool : IDisposable
     Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction);
 
     /// <summary>
+    /// [Experimental] Registers an async-aware loop-frame action to a pooled looper and returns <see cref="Task"/> to wait for completion.
+    /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction, LooperActionOptions options);
+
+    /// <summary>
     /// [Experimental] Registers an async-aware loop-frame action with state object to a pooled looper and returns <see cref="Task"/> to wait for completion.
     /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
     /// </summary>
@@ -38,6 +64,16 @@ public interface ILogicLooperPool : IDisposable
     /// <param name="state"></param>
     /// <returns></returns>
     Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state);
+
+    /// <summary>
+    /// [Experimental] Registers an async-aware loop-frame action with state object to a pooled looper and returns <see cref="Task"/> to wait for completion.
+    /// An asynchronous action is executed across multiple frames, differ from the synchronous version.
+    /// </summary>
+    /// <param name="loopAction"></param>
+    /// <param name="state"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options);
 
     /// <summary>
     /// Stops all action loop of the loopers.

--- a/src/LogicLooper/Internal/NotInitializedLogicLooperPool.cs
+++ b/src/LogicLooper/Internal/NotInitializedLogicLooperPool.cs
@@ -7,13 +7,25 @@ internal class NotInitializedLogicLooperPool : ILogicLooperPool
     public Task RegisterActionAsync(LogicLooperActionDelegate loopAction)
         => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
 
+    public Task RegisterActionAsync(LogicLooperActionDelegate loopAction, LooperActionOptions options)
+        => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
+
     public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state)
+        => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
+
+    public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
         => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
 
     public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
         => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
 
+    public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction, LooperActionOptions options)
+        => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
+
     public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
+        => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
+
+    public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
         => throw new InvalidOperationException("LogicLooper.Shared is not initialized yet.");
 
     public Task ShutdownAsync(TimeSpan shutdownDelay)

--- a/src/LogicLooper/LogicLooper.cs
+++ b/src/LogicLooper/LogicLooper.cs
@@ -212,6 +212,11 @@ public sealed class LogicLooper : ILogicLooper, IDisposable
 
     private Task RegisterActionAsyncCore(LooperAction action)
     {
+        if (action.Options.TargetFrameRateOverride is { } targetFrameRateOverride && targetFrameRateOverride > this.TargetFrameRate)
+        {
+            throw new InvalidOperationException("Option 'TargetFrameRateOverride' must be less than Looper's target frame rate.");
+        }
+
         lock (_lockQueue)
         {
             if (_isRunning)

--- a/src/LogicLooper/LogicLooperActionContext.cs
+++ b/src/LogicLooper/LogicLooperActionContext.cs
@@ -14,6 +14,11 @@ public readonly struct LogicLooperActionContext
     /// Gets a current frame that elapsed since beginning the looper is started.
     /// </summary>
     public long CurrentFrame { get; }
+    
+    /// <summary>
+    /// Gets a timestamp for begin of the current frame.
+    /// </summary>
+    public long FrameBeginTimestamp { get; }
 
     /// <summary>
     /// Gets an elapsed time since the previous frame has proceeded. This is the equivalent to Time.deltaTime on Unity.
@@ -25,10 +30,11 @@ public readonly struct LogicLooperActionContext
     /// </summary>
     public CancellationToken CancellationToken { get; }
 
-    public LogicLooperActionContext(ILogicLooper looper, long currentFrame, TimeSpan elapsedTimeFromPreviousFrame, CancellationToken cancellationToken)
+    public LogicLooperActionContext(ILogicLooper looper, long currentFrame, long frameBeginTimestamp, TimeSpan elapsedTimeFromPreviousFrame, CancellationToken cancellationToken)
     {
         Looper = looper ?? throw new ArgumentNullException(nameof(looper));
         CurrentFrame = currentFrame;
+        FrameBeginTimestamp = frameBeginTimestamp;
         ElapsedTimeFromPreviousFrame = elapsedTimeFromPreviousFrame;
         CancellationToken = cancellationToken;
     }

--- a/src/LogicLooper/LogicLooperPool.cs
+++ b/src/LogicLooper/LogicLooperPool.cs
@@ -44,16 +44,32 @@ public sealed partial class LogicLooperPool : ILogicLooperPool, IDisposable
         => GetLooper().RegisterActionAsync(loopAction);
 
     /// <inheritdoc />
+    public Task RegisterActionAsync(LogicLooperActionDelegate loopAction, LooperActionOptions options)
+        => GetLooper().RegisterActionAsync(loopAction, options);
+
+    /// <inheritdoc />
     public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state)
         => GetLooper().RegisterActionAsync(loopAction, state);
+
+    /// <inheritdoc />
+    public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
+        => GetLooper().RegisterActionAsync(loopAction, state, options);
 
     /// <inheritdoc />
     public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
         => GetLooper().RegisterActionAsync(loopAction);
 
     /// <inheritdoc />
+    public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction, LooperActionOptions options)
+        => GetLooper().RegisterActionAsync(loopAction, options);
+
+    /// <inheritdoc />
     public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
         => GetLooper().RegisterActionAsync(loopAction, state);
+
+    /// <inheritdoc />
+    public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
+        => GetLooper().RegisterActionAsync(loopAction, state, options);
 
     /// <inheritdoc />
     public async Task ShutdownAsync(TimeSpan shutdownDelay)

--- a/src/LogicLooper/LooperActionOptions.cs
+++ b/src/LogicLooper/LooperActionOptions.cs
@@ -1,5 +1,9 @@
 namespace Cysharp.Threading;
 
+/// <summary>
+/// Provides options for the loop-action.
+/// </summary>
+/// <param name="TargetFrameRateOverride">Set a override value for the target frame rate. LogicLooper tries to get as close to the target value as possible, but it is not as accurate as the Looper's frame rate.</param>
 public record LooperActionOptions(int? TargetFrameRateOverride = null)
 {
     public static LooperActionOptions Default { get; } = new LooperActionOptions();

--- a/src/LogicLooper/LooperActionOptions.cs
+++ b/src/LogicLooper/LooperActionOptions.cs
@@ -1,0 +1,6 @@
+namespace Cysharp.Threading;
+
+public record LooperActionOptions(int? TargetFrameRateOverride = null)
+{
+    public static LooperActionOptions Default { get; } = new LooperActionOptions();
+}

--- a/src/LogicLooper/ManualLogicLooperPool.cs
+++ b/src/LogicLooper/ManualLogicLooperPool.cs
@@ -48,18 +48,34 @@ public sealed class ManualLogicLooperPool : ILogicLooperPool
     /// <inheritdoc />
     public Task RegisterActionAsync(LogicLooperActionDelegate loopAction)
         => Loopers[0].RegisterActionAsync(loopAction);
+    
+    /// <inheritdoc />
+    public Task RegisterActionAsync(LogicLooperActionDelegate loopAction, LooperActionOptions options)
+        => Loopers[0].RegisterActionAsync(loopAction, options);
 
     /// <inheritdoc />
     public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state)
         => Loopers[0].RegisterActionAsync(loopAction, state);
 
     /// <inheritdoc />
+    public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
+        => Loopers[0].RegisterActionAsync(loopAction, state, options);
+
+    /// <inheritdoc />
     public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
         => Loopers[0].RegisterActionAsync(loopAction);
 
     /// <inheritdoc />
+    public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction, LooperActionOptions options)
+        => Loopers[0].RegisterActionAsync(loopAction, options);
+
+    /// <inheritdoc />
     public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
         => Loopers[0].RegisterActionAsync(loopAction, state);
+
+    /// <inheritdoc />
+    public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
+        => Loopers[0].RegisterActionAsync(loopAction, state, options);
 
     /// <inheritdoc />
     public Task ShutdownAsync(TimeSpan shutdownDelay)

--- a/test/LogicLooper.Test/LogicLooperTest.cs
+++ b/test/LogicLooper.Test/LogicLooperTest.cs
@@ -284,8 +284,7 @@ public class LogicLooperTest
         await Task.Delay(100);
         count.Should().Be(1);
     }
-    
-    
+
     [Theory]
     [InlineData(60, 10)]
     [InlineData(30, 10)]
@@ -334,5 +333,13 @@ public class LogicLooperTest
 
         frameCount.Should().Be(lastFrameNum);
         fps.Should().BeInRange(overrideTargetFps-2, overrideTargetFps + 2);
+    }
+
+    [Fact]
+    public async Task TargetFrameRateOverride_Invalid()
+    {
+        using var looper = new Cysharp.Threading.LogicLooper(30);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await looper.RegisterActionAsync((in LogicLooperActionContext _) => false, LooperActionOptions.Default with { TargetFrameRateOverride = 31 }));
     }
 }

--- a/test/LogicLooper.Test/LogicLooperTest.cs
+++ b/test/LogicLooper.Test/LogicLooperTest.cs
@@ -300,8 +300,14 @@ public class LogicLooperTest
         var beginTimestamp = DateTime.Now.Ticks;
         var lastTimestamp = beginTimestamp;
         var fps = 0d;
+
+        var lastFrameNum = 0L;
+        var frameCount = -1L; // CurrentFrame will be started from 0
         var task = looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
         {
+            frameCount++;
+            lastFrameNum = ctx.CurrentFrame;
+            
             var now = DateTime.Now.Ticks;
             var elapsedFromBeginMilliseconds = (now - beginTimestamp) / TimeSpan.TicksPerMillisecond;
             var elapsedFromPreviousFrameMilliseconds = (now - lastTimestamp) / TimeSpan.TicksPerMillisecond;
@@ -326,6 +332,7 @@ public class LogicLooperTest
 
         looper.ApproximatelyRunningActions.Should().Be(0);
 
+        frameCount.Should().Be(lastFrameNum);
         fps.Should().BeInRange(overrideTargetFps-2, overrideTargetFps + 2);
     }
 }


### PR DESCRIPTION
`TargetFrameRateOverride` option allows to override the frame rate for each action. This can be useful in cases where you want to mix multiple frame rates, such as expecting the main loop to run at 30fps, but wanting some actions to be called at 5fps.

You can also set the frame rate for each Looper that executes the loops, but the design of LogicLooper is 1-loop per thread, so in principle we expect a number of Loopers in accordance with the number of cores. By setting the frame rate for each action, you can keep the number of Loopers fixed even if the workload changes.

```csharp
using var looper = new LogicLooper(60); // 60 fps

await looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
{
    // Something to do ...
    return true;
}); // The action will be called at 60fps.

await looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
{
    // Something to do (low priority) ...
    return true;
}, LoopActionOptions.Default with { TargetFrameRateOverride = 10 }); // The action will be called at 10fps.
```

The granularity of action execution changes based on the execution frequency of the main loop itself. This means that the accuracy may be inferior to the target frame rate of the Looper.
