### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -20,7 +20,10 @@ jobs:
       - run: dotnet test -c Debug --no-build
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
+          name: nuget
           path: ./src/LogicLooper/bin/Debug/*.*nupkg
+          retention-days: 1
+
   test-release-build:
     name: Run tests using Release build
     needs: [ build-debug ]

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -18,7 +18,7 @@ jobs:
       - run: dotnet build -c Debug -p:DefineConstants=RUNNING_IN_CI
       - run: dotnet pack ./src/LogicLooper/LogicLooper.csproj -c Debug --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
       - run: dotnet test -c Debug --no-build
-      - uses: actions/upload-artifact@v4
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           path: ./src/LogicLooper/bin/Debug/*.*nupkg
   test-release-build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           name: nuget
           path: ./publish
+          retention-days: 1
 
   create-release:
     needs: [build-dotnet]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,7 @@ jobs:
       - run: dotnet build -c Release -p:VersionPrefix=${{ inputs.tag }} -p:DefineConstants=RUNNING_IN_CI
       - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release --no-build -p:VersionPrefix=${{ inputs.tag }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish
-      - uses: actions/upload-artifact@v4
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
