### PR TITLE
LogicLooper.Current also returns an instance when running in ManualLogicLooper

### DIFF
--- a/src/LogicLooper/LogicLooper.cs
+++ b/src/LogicLooper/LogicLooper.cs
@@ -22,12 +22,18 @@ public sealed class LogicLooper : ILogicLooper, IDisposable
     private static int _looperSequence = 0;
 
     [ThreadStatic]
-    private static LogicLooper? _threadLocalLooper = default;
+    private static ILogicLooper? _threadLocalLooper = default;
 
     /// <summary>
     /// Gets a looper of the current thread.
     /// </summary>
-    public static LogicLooper? Current => _threadLocalLooper;
+    public static ILogicLooper? Current
+    {
+        get => _threadLocalLooper;
+
+        // NOTE: Setter to set from ManualLogicLooper for testing purposes
+        internal set => _threadLocalLooper = value;
+    }
 
     private readonly int _looperId;
     private readonly Thread _runLoopThread;
@@ -235,8 +241,9 @@ public sealed class LogicLooper : ILogicLooper, IDisposable
 
     private static void StartRunLoop(object? state)
     {
-        _threadLocalLooper = ((LogicLooper)state!);
-        _threadLocalLooper.RunLoop();
+        var logicLooper = ((LogicLooper)state!);
+        _threadLocalLooper = logicLooper;
+        logicLooper.RunLoop();
     }
 
     private void RunLoop()

--- a/test/LogicLooper.Test/ManualLogicLooperTest.cs
+++ b/test/LogicLooper.Test/ManualLogicLooperTest.cs
@@ -175,4 +175,24 @@ public class ManualLogicLooperTest
         looper.ApproximatelyRunningActions.Should().Be(0);
         t1.IsCompletedSuccessfully.Should().BeTrue();
     }
+
+    [Fact]
+    public void LogicLooper_Current()
+    {
+        Cysharp.Threading.LogicLooper.Current.Should().BeNull();
+
+        var looper = new ManualLogicLooper(60.0);
+        looper.TargetFrameRate.Should().Be(60.0);
+
+        var currentLogicLooperInAction = default(ILogicLooper);
+        looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
+        {
+            currentLogicLooperInAction = Cysharp.Threading.LogicLooper.Current;
+            return false;
+        });
+        looper.Tick();
+
+        currentLogicLooperInAction.Should().Be(looper);
+        Cysharp.Threading.LogicLooper.Current.Should().BeNull();
+    }
 }


### PR DESCRIPTION
LogicLooper.Current returns null when retrieved within ManualLogicLooper, which causes problems in some situations, such as unit testing.