### PR TITLE
Remove Fluent Assertions

### DIFF
--- a/test/LogicLooper.Test/LogicLooper.Test.csproj
+++ b/test/LogicLooper.Test/LogicLooper.Test.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/test/LogicLooper.Test/LogicLooperCoroutineTest.cs
+++ b/test/LogicLooper.Test/LogicLooperCoroutineTest.cs
@@ -18,19 +18,19 @@ public class LogicLooperCoroutineTest
                 startFrame = ctx.CurrentFrame;
                 coroutine = ctx.RunCoroutine(async ctx2 =>
                 {
-                    ctx2.CurrentFrame.Should().Be(startFrame);
+                    Assert.Equal(startFrame, ctx2.CurrentFrame);
                         
                     await ctx2.DelayFrame(60);
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 60);
+                    Assert.Equal(startFrame + 60, ctx2.CurrentFrame);
 
                     await ctx2.DelayNextFrame();
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 61);
+                    Assert.Equal(startFrame + 61, ctx2.CurrentFrame);
 
                     await ctx2.Delay(TimeSpan.FromMilliseconds(16.66666));
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 62);
+                    Assert.Equal(startFrame + 62, ctx2.CurrentFrame);
                 });
             }
 
@@ -40,9 +40,9 @@ public class LogicLooperCoroutineTest
         if (coroutine.Exception != null)
             throw coroutine.Exception;
 
-        coroutine.IsCompleted.Should().BeTrue();
-        coroutine.IsCompletedSuccessfully.Should().BeTrue();
-        coroutine.IsFaulted.Should().BeFalse();
+        Assert.True(coroutine.IsCompleted);
+        Assert.True(coroutine.IsCompletedSuccessfully);
+        Assert.False(coroutine.IsFaulted);
     }
 
     [Fact]
@@ -59,19 +59,19 @@ public class LogicLooperCoroutineTest
                 startFrame = ctx.CurrentFrame;
                 coroutine = ctx.RunCoroutine(async ctx2 =>
                 {
-                    ctx2.CurrentFrame.Should().Be(startFrame);
+                    Assert.Equal(startFrame, ctx2.CurrentFrame);
 
                     await ctx2.DelayFrame(60);
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 60);
+                    Assert.Equal(startFrame + 60, ctx2.CurrentFrame);
 
                     await ctx2.DelayNextFrame();
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 61);
+                    Assert.Equal(startFrame + 61, ctx2.CurrentFrame);
 
                     await ctx2.Delay(TimeSpan.FromMilliseconds(16.66666));
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 62);
+                    Assert.Equal(startFrame + 62, ctx2.CurrentFrame);
 
                     return 12345;
                 });
@@ -83,11 +83,11 @@ public class LogicLooperCoroutineTest
         if (coroutine.Exception != null)
             throw coroutine.Exception;
 
-        coroutine.IsCompleted.Should().BeTrue();
-        coroutine.IsCompletedSuccessfully.Should().BeTrue();
-        coroutine.IsFaulted.Should().BeFalse();
+        Assert.True(coroutine.IsCompleted);
+        Assert.True(coroutine.IsCompletedSuccessfully);
+        Assert.False(coroutine.IsFaulted);
 
-        coroutine.Result.Should().Be(12345);
+        Assert.Equal(12345, coroutine.Result);
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class LogicLooperCoroutineTest
                 startFrame = ctx.CurrentFrame;
                 coroutine = ctx.RunCoroutine(async ctx2 =>
                 {
-                    ctx2.CurrentFrame.Should().Be(startFrame);
+                    Assert.Equal(startFrame, ctx2.CurrentFrame);
 
                     await ctx2.DelayFrame(5);
 
@@ -115,12 +115,12 @@ public class LogicLooperCoroutineTest
             return !coroutine.IsCompleted;
         });
 
-        coroutine.IsCompleted.Should().BeTrue();
-        coroutine.IsCompletedSuccessfully.Should().BeFalse();
-        coroutine.IsFaulted.Should().BeTrue();
+        Assert.True(coroutine.IsCompleted);
+        Assert.False(coroutine.IsCompletedSuccessfully);
+        Assert.True(coroutine.IsFaulted);
 
-        coroutine.Exception.Should().NotBeNull();
-        coroutine.Exception.Message.Should().Be("ThrownFromCoroutine");
+        Assert.NotNull(coroutine.Exception);
+        Assert.Equal("ThrownFromCoroutine", coroutine.Exception.Message);
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class LogicLooperCoroutineTest
                 startFrame = ctx.CurrentFrame;
                 coroutine = ctx.RunCoroutine(async ctx2 =>
                 {
-                    ctx2.CurrentFrame.Should().Be(startFrame);
+                    Assert.Equal(startFrame, ctx2.CurrentFrame);
 
                     await ctx2.DelayFrame(5);
 
@@ -152,12 +152,12 @@ public class LogicLooperCoroutineTest
             return !coroutine.IsCompleted;
         });
 
-        coroutine.IsCompleted.Should().BeTrue();
-        coroutine.IsCompletedSuccessfully.Should().BeFalse();
-        coroutine.IsFaulted.Should().BeTrue();
+        Assert.True(coroutine.IsCompleted);
+        Assert.False(coroutine.IsCompletedSuccessfully);
+        Assert.True(coroutine.IsFaulted);
 
-        coroutine.Exception.Should().NotBeNull();
-        coroutine.Exception.Message.Should().Be("ThrownFromCoroutine");
+        Assert.NotNull(coroutine.Exception);
+        Assert.Equal("ThrownFromCoroutine", coroutine.Exception.Message);
     }
 
 
@@ -189,11 +189,11 @@ public class LogicLooperCoroutineTest
                         {
                             for (var k = 0; k < coroutineLoopCount; k++)
                             {
-                                ctx2.Looper.Should().Be(looper);
+                                Assert.Equal(looper, ctx2.Looper);
 
                                 await ctx2.DelayFrame(1);
 
-                                ctx2.Looper.Should().Be(looper);
+                                Assert.Equal(looper, ctx2.Looper);
 
                                 Interlocked.Increment(ref count);
                             }
@@ -215,7 +215,7 @@ public class LogicLooperCoroutineTest
 
         await Task.WhenAll(tasks);
 
-        count.Should().Be(loopsCount * coroutineCountPerLoop * coroutineLoopCount);
+        Assert.Equal(loopsCount * coroutineCountPerLoop * coroutineLoopCount, count);
     }
 
     [Fact]
@@ -232,15 +232,15 @@ public class LogicLooperCoroutineTest
                 startFrame = ctx.CurrentFrame;
                 coroutine = ctx.RunCoroutine(async ctx2 =>
                 {
-                    ctx2.CurrentFrame.Should().Be(startFrame);
+                    Assert.Equal(startFrame, ctx2.CurrentFrame);
 
                     await ctx2.DelayNextFrame();
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 1);
+                    Assert.Equal(startFrame + 1, ctx2.CurrentFrame);
 
                     await ctx2.DelayNextFrame();
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 2);
+                    Assert.Equal(startFrame + 2, ctx2.CurrentFrame);
                 });
             }
 
@@ -250,9 +250,9 @@ public class LogicLooperCoroutineTest
         if (coroutine.Exception != null)
             throw coroutine.Exception;
 
-        coroutine.IsCompleted.Should().BeTrue();
-        coroutine.IsCompletedSuccessfully.Should().BeTrue();
-        coroutine.IsFaulted.Should().BeFalse();
+        Assert.True(coroutine.IsCompleted);
+        Assert.True(coroutine.IsCompletedSuccessfully);
+        Assert.False(coroutine.IsFaulted);
     }
 
     [Fact]
@@ -269,15 +269,15 @@ public class LogicLooperCoroutineTest
                 startFrame = ctx.CurrentFrame;
                 coroutine = ctx.RunCoroutine(async ctx2 =>
                 {
-                    ctx2.CurrentFrame.Should().Be(startFrame);
+                    Assert.Equal(startFrame, ctx2.CurrentFrame);
 
                     await ctx2.DelayFrame(30);
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 30);
+                    Assert.Equal(startFrame + 30, ctx2.CurrentFrame);
 
                     await ctx2.DelayFrame(30);
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 30 + 30);
+                    Assert.Equal(startFrame + 30 + 30, ctx2.CurrentFrame);
                 });
             }
 
@@ -287,9 +287,9 @@ public class LogicLooperCoroutineTest
         if (coroutine.Exception != null)
             throw coroutine.Exception;
 
-        coroutine.IsCompleted.Should().BeTrue();
-        coroutine.IsCompletedSuccessfully.Should().BeTrue();
-        coroutine.IsFaulted.Should().BeFalse();
+        Assert.True(coroutine.IsCompleted);
+        Assert.True(coroutine.IsCompletedSuccessfully);
+        Assert.False(coroutine.IsFaulted);
     }
 
     [Fact]
@@ -306,15 +306,15 @@ public class LogicLooperCoroutineTest
                 startFrame = ctx.CurrentFrame;
                 coroutine = ctx.RunCoroutine(async ctx2 =>
                 {
-                    ctx2.CurrentFrame.Should().Be(startFrame);
+                    Assert.Equal(startFrame, ctx2.CurrentFrame);
 
                     await ctx2.Delay(TimeSpan.FromMilliseconds(16.66666));
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 1);
+                    Assert.Equal(startFrame + 1, ctx2.CurrentFrame);
 
                     await ctx2.Delay(TimeSpan.FromMilliseconds(33.33333));
 
-                    ctx2.CurrentFrame.Should().Be(startFrame + 1 + 2);
+                    Assert.Equal(startFrame + 1 + 2, ctx2.CurrentFrame);
                 });
             }
 
@@ -324,8 +324,8 @@ public class LogicLooperCoroutineTest
         if (coroutine.Exception != null)
             throw coroutine.Exception;
 
-        coroutine.IsCompleted.Should().BeTrue();
-        coroutine.IsCompletedSuccessfully.Should().BeTrue();
-        coroutine.IsFaulted.Should().BeFalse();
+        Assert.True(coroutine.IsCompleted);
+        Assert.True(coroutine.IsCompletedSuccessfully);
+        Assert.False(coroutine.IsFaulted);
     }
 }

--- a/test/LogicLooper.Test/LogicLooperPoolTest.cs
+++ b/test/LogicLooper.Test/LogicLooperPoolTest.cs
@@ -8,16 +8,16 @@ public class LogicLooperPoolTest
     public void Create()
     {
         using var pool = new LogicLooperPool(60, 4, RoundRobinLogicLooperPoolBalancer.Instance);
-        pool.Loopers.Should().HaveCount(4);
-        pool.Loopers[0].TargetFrameRate.Should().BeInRange(60, 60.1);
+        Assert.Equal(4, pool.Loopers.Count());
+        Assert.InRange(pool.Loopers[0].TargetFrameRate, 60, 60.1);
     }
 
     [Fact]
     public void Create_TimeSpan()
     {
         using var pool = new LogicLooperPool(TimeSpan.FromMilliseconds(16.666), 4, RoundRobinLogicLooperPoolBalancer.Instance);
-        pool.Loopers.Should().HaveCount(4);
-        pool.Loopers[0].TargetFrameRate.Should().BeInRange(60, 60.1);
+        Assert.Equal(4, pool.Loopers.Count());
+        Assert.InRange(pool.Loopers[0].TargetFrameRate, 60, 60.1);
     }
 
     [Fact]
@@ -41,18 +41,18 @@ public class LogicLooperPoolTest
 
         Thread.Sleep(1000);
 
-        executedCount.Should().Be(actionCount * loopCount);
+        Assert.Equal(actionCount * loopCount, executedCount);
     }
 
     [Fact]
     public void GetLooper()
     {
         using var pool = new LogicLooperPool(60, 4, new FakeSequentialLogicLooperPoolBalancer());
-        pool.GetLooper().Should().Be(pool.Loopers[0]);
-        pool.GetLooper().Should().Be(pool.Loopers[1]);
-        pool.GetLooper().Should().Be(pool.Loopers[2]);
-        pool.GetLooper().Should().Be(pool.Loopers[3]);
-        pool.GetLooper().Should().Be(pool.Loopers[0]);
+        Assert.Equal(pool.Loopers[0], pool.GetLooper());
+        Assert.Equal(pool.Loopers[1], pool.GetLooper());
+        Assert.Equal(pool.Loopers[2], pool.GetLooper());
+        Assert.Equal(pool.Loopers[3], pool.GetLooper());
+        Assert.Equal(pool.Loopers[0], pool.GetLooper());
     }
 
     class FakeSequentialLogicLooperPoolBalancer : ILogicLooperPoolBalancer

--- a/test/LogicLooper.Test/LogicLooperSynchronizationContextTest.cs
+++ b/test/LogicLooper.Test/LogicLooperSynchronizationContextTest.cs
@@ -25,17 +25,17 @@ public class LogicLooperSynchronizationContextTest
             count++;
         }, null);
 
-        count.Should().Be(0);
+        Assert.Equal(0, count);
         looper.Tick();
-        count.Should().Be(3);
+        Assert.Equal(3, count);
         looper.Tick();
-        count.Should().Be(3);
+        Assert.Equal(3, count);
         syncContext.Post(_ =>
         {
             count++;
         }, null);
         looper.Tick();
-        count.Should().Be(4);
+        Assert.Equal(4, count);
     }
 
     [Fact]
@@ -55,15 +55,15 @@ public class LogicLooperSynchronizationContextTest
         });
 
         looper.Tick();
-        result.Should().BeEquivalentTo(new[] { "1" });
+        Assert.Equal(new[] { "1" }, result);
 
         await Task.Delay(500).ConfigureAwait(false);
 
         looper.Tick(); // Run continuation
         looper.Tick(); // Wait for complete action
-        result.Should().BeEquivalentTo(new[] { "1", "2" });
+        Assert.Equal(new[] { "1", "2" }, result);
 
-        task.IsCompleted.Should().BeTrue();
+        Assert.True(task.IsCompleted);
     }
 
     [Fact]
@@ -74,10 +74,10 @@ public class LogicLooperSynchronizationContextTest
         SynchronizationContext.SetSynchronizationContext(syncContext); // This context is used when advancing frame within the Tick method. Use `ConfigureAwait(false)` in the following codes.
         var t = looper.RegisterActionAsync((in LogicLooperActionContext ctx) => false);
 
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
         looper.Tick();
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        t.IsCompleted.Should().BeTrue();
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.True(t.IsCompleted);
     }
     
     [Fact]
@@ -92,14 +92,14 @@ public class LogicLooperSynchronizationContextTest
             return false;
         });
 
-        looper.ApproximatelyRunningActions.Should().Be(1); // User-Action
+        Assert.Equal(1, looper.ApproximatelyRunningActions); // User-Action
         looper.Tick();
         await Task.Delay(100).ConfigureAwait(false);
-        looper.ApproximatelyRunningActions.Should().Be(2); // User-Action + DequeLoopAction
+        Assert.Equal(2, looper.ApproximatelyRunningActions); // User-Action + DequeLoopAction
         looper.Tick(); // Run continuation
         looper.Tick(); // Wait for complete action
-        t.IsCompleted.Should().BeTrue();
-        looper.ApproximatelyRunningActions.Should().Be(1); // DequeueLoopAction
+        Assert.True(t.IsCompleted);
+        Assert.Equal(1, looper.ApproximatelyRunningActions); // DequeueLoopAction
     }
 
 }

--- a/test/LogicLooper.Test/LogicLooperTest.cs
+++ b/test/LogicLooper.Test/LogicLooperTest.cs
@@ -12,8 +12,8 @@ public class LogicLooperTest
     {
         using var looper = new Cysharp.Threading.LogicLooper(TimeSpan.FromMilliseconds(targetFrameTimeMs));
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        looper.TargetFrameRate.Should().Be(1000 / (double)targetFrameTimeMs);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.Equal(1000 / (double)targetFrameTimeMs, looper.TargetFrameRate);
 
         var beginTimestamp = DateTime.Now.Ticks;
         var lastTimestamp = beginTimestamp;
@@ -36,15 +36,15 @@ public class LogicLooperTest
         // wait for moving action from queue to actions.
         await Task.Delay(100);
 
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
 
         await task;
 
         await Task.Delay(100);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
-        fps.Should().BeInRange(looper.TargetFrameRate - 2, looper.TargetFrameRate + 2);
+        Assert.InRange(fps, looper.TargetFrameRate - 2, looper.TargetFrameRate + 2);
     }
 
     [Theory]
@@ -55,8 +55,8 @@ public class LogicLooperTest
     {
         using var looper = new Cysharp.Threading.LogicLooper(targetFps);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        ((int)looper.TargetFrameRate).Should().Be(targetFps);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.Equal(targetFps, ((int)looper.TargetFrameRate));
 
         var beginTimestamp = DateTime.Now.Ticks;
         var lastTimestamp = beginTimestamp;
@@ -79,15 +79,15 @@ public class LogicLooperTest
         // wait for moving action from queue to actions.
         await Task.Delay(100);
 
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
 
         await task;
 
         await Task.Delay(100);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
-        fps.Should().BeInRange(targetFps-2, targetFps + 2);
+        Assert.InRange(fps, targetFps - 2, targetFps + 2);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class LogicLooperTest
         });
 
         await Task.Delay(100);
-        count.Should().Be(1);
+        Assert.Equal(1, count);
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class LogicLooperTest
         }));
 
         await Task.Delay(100);
-        count.Should().Be(1);
+        Assert.Equal(1, count);
     }
 
     [Fact]
@@ -135,7 +135,7 @@ public class LogicLooperTest
         });
 
         await Task.Delay(100);
-        currentFrame.Should().Be(10);
+        Assert.Equal(10, currentFrame);
     }
 
     [Fact]
@@ -144,12 +144,12 @@ public class LogicLooperTest
         using var looper = new Cysharp.Threading.LogicLooper(60);
 
         var runLoopTask = looper.RegisterActionAsync((in LogicLooperActionContext ctx) => !ctx.CancellationToken.IsCancellationRequested);
-        runLoopTask.IsCompleted.Should().BeFalse();
+        Assert.False(runLoopTask.IsCompleted);
 
         var shutdownTask = looper.ShutdownAsync(TimeSpan.FromMilliseconds(500));
         await Task.Delay(50);
-        runLoopTask.IsCompleted.Should().BeTrue();
-        shutdownTask.IsCompleted.Should().BeFalse();
+        Assert.True(runLoopTask.IsCompleted);
+        Assert.False(shutdownTask.IsCompleted);
 
         await shutdownTask;
     }
@@ -166,16 +166,16 @@ public class LogicLooperTest
             count++;
             return !ctx.CancellationToken.IsCancellationRequested;
         });
-        runLoopTask.IsCompleted.Should().BeFalse();
+        Assert.False(runLoopTask.IsCompleted);
 
         var shutdownTask = looper.ShutdownAsync(TimeSpan.FromMilliseconds(500));
         await Task.Delay(50);
-        runLoopTask.IsCompleted.Should().BeTrue();
+        Assert.True(runLoopTask.IsCompleted);
         var count2 = count;
-        shutdownTask.IsCompleted.Should().BeFalse();
+        Assert.False(shutdownTask.IsCompleted);
 
         await shutdownTask;
-        count.Should().Be(count);
+        Assert.Equal(count, count);
     }
 
     [Fact]
@@ -189,7 +189,7 @@ public class LogicLooperTest
             signal.Set();
             return !ctx.CancellationToken.IsCancellationRequested;
         });
-        runLoopTask.IsCompleted.Should().BeFalse();
+        Assert.False(runLoopTask.IsCompleted);
 
         signal.Wait();
         var shutdownTask = looper.ShutdownAsync(TimeSpan.Zero);
@@ -213,7 +213,7 @@ public class LogicLooperTest
         await Task.Delay(1000);
         await looper.ShutdownAsync(TimeSpan.Zero);
 
-        looper.LastProcessingDuration.TotalMilliseconds.Should().BeInRange(95, 105);
+        Assert.InRange(looper.LastProcessingDuration.TotalMilliseconds, 95, 105);
     }
 
     [Fact]
@@ -240,7 +240,7 @@ public class LogicLooperTest
         await runLoopTask;
 
         // 2 x 3
-        results.Should().BeEquivalentTo(new[] { managedThreadId, managedThreadId, managedThreadId, managedThreadId, managedThreadId, managedThreadId });
+        Assert.Equal(new[] { managedThreadId, managedThreadId, managedThreadId, managedThreadId, managedThreadId, managedThreadId }, results);
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public class LogicLooperTest
 
         await runLoopTask;
 
-        results.Should().BeEquivalentTo(new[] { managedThreadId, managedThreadId, managedThreadId });
+        Assert.Equal(new[] { managedThreadId, managedThreadId, managedThreadId }, results);
     }
     
     [Fact]
@@ -281,7 +281,7 @@ public class LogicLooperTest
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await runLoopTask);
         await Task.Delay(100);
-        count.Should().Be(1);
+        Assert.Equal(1, count);
     }
 
     [Theory]
@@ -292,8 +292,8 @@ public class LogicLooperTest
     {
         using var looper = new Cysharp.Threading.LogicLooper(targetFps);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        ((int)looper.TargetFrameRate).Should().Be(targetFps);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.Equal(targetFps, ((int)looper.TargetFrameRate));
 
         var beginTimestamp = DateTime.Now.Ticks;
         var lastTimestamp = beginTimestamp;
@@ -322,16 +322,16 @@ public class LogicLooperTest
         // wait for moving action from queue to actions.
         await Task.Delay(100);
 
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
 
         await task;
 
         await Task.Delay(100);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
-        frameCount.Should().Be(lastFrameNum);
-        fps.Should().BeInRange(overrideTargetFps-2, overrideTargetFps + 2);
+        Assert.Equal(lastFrameNum, frameCount);
+        Assert.InRange(fps, overrideTargetFps - 2, overrideTargetFps + 2);
     }
 
     [Fact]
@@ -347,7 +347,7 @@ public class LogicLooperTest
     {
         using var looper = new Cysharp.Threading.LogicLooper(30);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
         var lastFrameNum = 0L;
         var overriddenFrameCount = -1L;
@@ -380,8 +380,8 @@ public class LogicLooperTest
         await Task.Delay(1100);
         cts.Cancel();
 
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
 
-        overriddenFrameCount.Should().Be(1);
+        Assert.Equal(1, overriddenFrameCount);
     }
 }

--- a/test/LogicLooper.Test/ManualLogicLooperPoolTest.cs
+++ b/test/LogicLooper.Test/ManualLogicLooperPoolTest.cs
@@ -8,8 +8,8 @@ public class ManualLogicLooperPoolTest
     public void Create()
     {
         var pool = new ManualLogicLooperPool(60.0);
-        pool.Loopers.Should().HaveCount(1);
-        pool.FakeLooper.TargetFrameRate.Should().Be(60.0);
+        Assert.Single(pool.Loopers);
+        Assert.Equal(60.0, pool.FakeLooper.TargetFrameRate);
     }
 
     [Fact]
@@ -21,10 +21,10 @@ public class ManualLogicLooperPoolTest
         {
             return false;
         });
-        pool.Loopers[0].ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, pool.Loopers[0].ApproximatelyRunningActions);
         pool.Tick();
-        pool.Loopers[0].ApproximatelyRunningActions.Should().Be(0);
-        t1.IsCompletedSuccessfully.Should().BeTrue();
+        Assert.Equal(0, pool.Loopers[0].ApproximatelyRunningActions);
+        Assert.True(t1.IsCompletedSuccessfully);
     }
 
     [Fact]
@@ -33,6 +33,6 @@ public class ManualLogicLooperPoolTest
         var pool = new ManualLogicLooperPool(60.0);
         var looper = pool.GetLooper();
 
-        looper.Should().Be(pool.FakeLooper);
+        Assert.Equal(pool.FakeLooper, looper);
     }
 }

--- a/test/LogicLooper.Test/ManualLogicLooperTest.cs
+++ b/test/LogicLooper.Test/ManualLogicLooperTest.cs
@@ -8,7 +8,7 @@ public class ManualLogicLooperTest
     public void Elapsed()
     {
         var looper = new ManualLogicLooper(60.0);
-        looper.TargetFrameRate.Should().Be(60.0);
+        Assert.Equal(60.0, looper.TargetFrameRate);
 
         var elapsed = default(TimeSpan);
         looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
@@ -18,14 +18,14 @@ public class ManualLogicLooperTest
         });
         looper.Tick();
 
-        elapsed.Should().BeCloseTo(TimeSpan.FromMilliseconds(1000 / 60), precision: 1);
+        Assert.InRange(elapsed.TotalMilliseconds, 16.6666, 16.9999);
     }
 
     [Fact]
     public void Elapsed_2()
     {
         var looper = new ManualLogicLooper(30.0);
-        looper.TargetFrameRate.Should().Be(30.0);
+        Assert.Equal(30.0, looper.TargetFrameRate);
 
         var elapsed = default(TimeSpan);
         looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
@@ -35,14 +35,14 @@ public class ManualLogicLooperTest
         });
         looper.Tick();
 
-        elapsed.Should().BeCloseTo(TimeSpan.FromMilliseconds(1000 / 30), precision: 1);
+        Assert.InRange(elapsed.TotalMilliseconds, 33.3333, 33.9999);
     }
 
     [Fact]
     public void Tick()
     {
         var looper = new ManualLogicLooper(60.0);
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
         var count = 0;
         var t1 = looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
@@ -50,29 +50,29 @@ public class ManualLogicLooperTest
             count++;
             return count != 3;
         });
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
 
-        count.Should().Be(0);
-        looper.CurrentFrame.Should().Be(0);
-        looper.Tick().Should().BeTrue();
-        count.Should().Be(1);
-        looper.CurrentFrame.Should().Be(1);
-        looper.Tick().Should().BeTrue();
-        count.Should().Be(2);
-        looper.CurrentFrame.Should().Be(2);
-        looper.Tick().Should().BeFalse();
-        count.Should().Be(3);
-        looper.CurrentFrame.Should().Be(3);
+        Assert.Equal(0, count);
+        Assert.Equal(0, looper.CurrentFrame);
+        Assert.True(looper.Tick());
+        Assert.Equal(1, count);
+        Assert.Equal(1, looper.CurrentFrame);
+        Assert.True(looper.Tick());
+        Assert.Equal(2, count);
+        Assert.Equal(2, looper.CurrentFrame);
+        Assert.False(looper.Tick());
+        Assert.Equal(3, count);
+        Assert.Equal(3, looper.CurrentFrame);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        t1.IsCompletedSuccessfully.Should().BeTrue();
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.True(t1.IsCompletedSuccessfully);
     }
 
     [Fact]
     public void Tick_Multiple()
     {
         var looper = new ManualLogicLooper(60.0);
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
         var count = 0;
         var t1 = looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
@@ -85,30 +85,30 @@ public class ManualLogicLooperTest
             count++;
             return count != 7;
         });
-        looper.ApproximatelyRunningActions.Should().Be(2);
+        Assert.Equal(2, looper.ApproximatelyRunningActions);
 
-        count.Should().Be(0);
-        looper.Tick().Should().BeTrue();
-        count.Should().Be(2);
-        looper.Tick().Should().BeTrue();
-        count.Should().Be(4);
-        looper.Tick().Should().BeTrue();
-        count.Should().Be(6);
-        looper.ApproximatelyRunningActions.Should().Be(1);
-        t1.IsCompletedSuccessfully.Should().BeTrue();
+        Assert.Equal(0, count);
+        Assert.True(looper.Tick());
+        Assert.Equal(2, count);
+        Assert.True(looper.Tick());
+        Assert.Equal(4, count);
+        Assert.True(looper.Tick());
+        Assert.Equal(6, count);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
+        Assert.True(t1.IsCompletedSuccessfully);
 
-        looper.Tick().Should().BeFalse();
-        count.Should().Be(7);
+        Assert.False(looper.Tick());
+        Assert.Equal(7, count);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        t2.IsCompletedSuccessfully.Should().BeTrue();
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.True(t2.IsCompletedSuccessfully);
     }
 
     [Fact]
     public void Tick_Count()
     {
         var looper = new ManualLogicLooper(60.0);
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
         var count = 0;
         var t1 = looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
@@ -116,19 +116,19 @@ public class ManualLogicLooperTest
             count++;
             return count != 3;
         });
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
 
-        looper.Tick(3).Should().BeFalse();
+        Assert.False(looper.Tick(3));
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        t1.IsCompletedSuccessfully.Should().BeTrue();
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.True(t1.IsCompletedSuccessfully);
     }
 
     [Fact]
     public void TickWhile()
     {
         var looper = new ManualLogicLooper(60.0);
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
         var count = 0;
         var t1 = looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
@@ -136,16 +136,16 @@ public class ManualLogicLooperTest
             count++;
             return true;
         });
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
 
-        count.Should().Be(0);
+        Assert.Equal(0, count);
 
         looper.TickWhile(() => count != 6);
 
-        count.Should().Be(6);
+        Assert.Equal(6, count);
 
-        looper.ApproximatelyRunningActions.Should().Be(1);
-        t1.IsCompletedSuccessfully.Should().BeFalse();
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
+        Assert.False(t1.IsCompletedSuccessfully);
     }
 
 
@@ -153,7 +153,7 @@ public class ManualLogicLooperTest
     public void RegisterActionAsync_State()
     {
         var looper = new ManualLogicLooper(60.0);
-        looper.ApproximatelyRunningActions.Should().Be(0);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
 
         var count = 0;
         var tuple = Tuple.Create("Foo", 123);
@@ -164,25 +164,25 @@ public class ManualLogicLooperTest
             count++;
             return count != 3;
         }, tuple);
-        looper.ApproximatelyRunningActions.Should().Be(1);
+        Assert.Equal(1, looper.ApproximatelyRunningActions);
 
-        looper.Tick().Should().BeTrue();
-        looper.Tick().Should().BeTrue();
-        looper.Tick().Should().BeFalse();
-        count.Should().Be(3);
-        receivedState.Should().Be(tuple);
+        Assert.True(looper.Tick());
+        Assert.True(looper.Tick());
+        Assert.False(looper.Tick());
+        Assert.Equal(3, count);
+        Assert.Equal(tuple, receivedState);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        t1.IsCompletedSuccessfully.Should().BeTrue();
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.True(t1.IsCompletedSuccessfully);
     }
 
     [Fact]
     public void LogicLooper_Current()
     {
-        Cysharp.Threading.LogicLooper.Current.Should().BeNull();
+        Assert.Null(Cysharp.Threading.LogicLooper.Current);
 
         var looper = new ManualLogicLooper(60.0);
-        looper.TargetFrameRate.Should().Be(60.0);
+        Assert.Equal(60.0, looper.TargetFrameRate);
 
         var currentLogicLooperInAction = default(ILogicLooper);
         looper.RegisterActionAsync((in LogicLooperActionContext ctx) =>
@@ -192,7 +192,7 @@ public class ManualLogicLooperTest
         });
         looper.Tick();
 
-        currentLogicLooperInAction.Should().Be(looper);
-        Cysharp.Threading.LogicLooper.Current.Should().BeNull();
+        Assert.Equal(looper, currentLogicLooperInAction);
+        Assert.Null(Cysharp.Threading.LogicLooper.Current);
     }
 }

--- a/test/LogicLooper.Test/SleepInteropTest.cs
+++ b/test/LogicLooper.Test/SleepInteropTest.cs
@@ -12,7 +12,7 @@ public class SleepInteropTest
         SleepInterop.Sleep(1);
         var end = Stopwatch.GetTimestamp();
         var elapsed = Stopwatch.GetElapsedTime(begin, end);
-        elapsed.TotalMilliseconds.Should().BeLessThan(16);
+        Assert.True(elapsed.TotalMilliseconds < 16);
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public class SleepInteropTest
         SleepInterop.Sleep(17);
         var end = Stopwatch.GetTimestamp();
         var elapsed = Stopwatch.GetElapsedTime(begin, end);
-        elapsed.TotalMilliseconds.Should().BeGreaterThan(16);
+        Assert.True(elapsed.TotalMilliseconds > 16);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class SleepInteropTest
         }).ToArray();
         foreach (var thread in threads)
         {
-            thread.Join(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            Assert.True(thread.Join(TimeSpan.FromSeconds(10)));
         }
     }
 }

--- a/test/LogicLooper.Test/StressTest.cs
+++ b/test/LogicLooper.Test/StressTest.cs
@@ -45,8 +45,8 @@ public class StressTest
             Thread.Sleep(100);
         }
 
-        launchedCount.Should().Be(actionCount);
-        executedCount.Should().Be(actionCount * loopCount);
+        Assert.Equal(actionCount, launchedCount);
+        Assert.Equal(actionCount * loopCount, executedCount);
     }
 
     [Theory]
@@ -57,8 +57,8 @@ public class StressTest
     {
         using var looper = new Cysharp.Threading.LogicLooper(targetFps);
 
-        looper.ApproximatelyRunningActions.Should().Be(0);
-        looper.TargetFrameRate.Should().BeInRange(targetFps-1, targetFps+1);
+        Assert.Equal(0, looper.ApproximatelyRunningActions);
+        Assert.InRange(looper.TargetFrameRate, targetFps - 1, targetFps + 1);
 
         var executedCount = 0;
         var launchedCount = 0;
@@ -96,7 +96,7 @@ public class StressTest
             Thread.Sleep(100);
         }
 
-        launchedCount.Should().Be(actionCount);
-        executedCount.Should().Be(actionCount * loopCount);
+        Assert.Equal(actionCount, launchedCount);
+        Assert.Equal(actionCount * loopCount, executedCount);
     }
 }

--- a/test/LogicLooper.Test/Usings.cs
+++ b/test/LogicLooper.Test/Usings.cs
@@ -1,2 +1,1 @@
 global using Xunit;
-global using FluentAssertions;


### PR DESCRIPTION
This PR removes Fluent Assertions dependencies and usages. This is due to an unacceptable license change in v8.

- https://github.com/fluentassertions/fluentassertions/pull/2943