### PR TITLE
Prevent direct disposal or shutdown of Loopers retrieved from LogicLooperPool.

### DIFF
--- a/src/LogicLooper/ILogicLooperPoolBalancer.cs
+++ b/src/LogicLooper/ILogicLooperPoolBalancer.cs
@@ -1,6 +1,14 @@
-namespace Cysharp.Threading;
+﻿namespace Cysharp.Threading;
 
+/// <summary>
+/// Defines a strategy for selecting an <see cref="ILogicLooper"/> instance from a pool of available loopers.
+/// </summary>
+/// <remarks>Implementations of this interface determine how a looper is chosen from the provided pool, which may
+/// affect load distribution, performance, or resource utilization.</remarks>
 public interface ILogicLooperPoolBalancer
 {
-    LogicLooper GetPooledLooper(LogicLooper[] pooledLoopers);
+    /// <summary>
+    /// Gets an available <see cref="ILogicLooper"/> instance from the specified pool.
+    /// </summary>
+    ILogicLooper GetPooledLooper(ILogicLooper[] pooledLoopers);
 }

--- a/src/LogicLooper/ILogicLooperPoolLooperFactory.cs
+++ b/src/LogicLooper/ILogicLooperPoolLooperFactory.cs
@@ -1,0 +1,30 @@
+﻿namespace Cysharp.Threading;
+
+/// <summary>
+/// Defines a factory for creating <see cref="ILogicLooper"/> instances.
+/// </summary>
+public interface ILogicLooperPoolLooperFactory
+{
+    /// <summary>
+    /// Creates a new <see cref="ILogicLooper"/> instance configured to operate with the specified target frame time.
+    /// </summary>
+    ILogicLooper Create(TimeSpan targetFrameTime);
+}
+
+/// <summary>
+/// Provides a default implementation of <see cref="ILogicLooperPoolLooperFactory"/> for creating logic loopers with a
+/// specified target frame time.
+/// </summary>
+public class DefaultLogicLooperPoolLooperFactory : ILogicLooperPoolLooperFactory
+{
+    /// <summary>
+    /// Gets the singleton instance of the <see cref="ILogicLooperPoolLooperFactory"/> used to create logic looper pool
+    /// looper objects.
+    /// </summary>
+    public static ILogicLooperPoolLooperFactory Instance { get; } = new DefaultLogicLooperPoolLooperFactory();
+
+    private DefaultLogicLooperPoolLooperFactory() { }
+
+    public ILogicLooper Create(TimeSpan targetFrameTime)
+        => new LogicLooper(targetFrameTime);
+}

--- a/src/LogicLooper/LogicLooperPool.Shared.cs
+++ b/src/LogicLooper/LogicLooperPool.Shared.cs
@@ -1,4 +1,4 @@
-using Cysharp.Threading.Internal;
+﻿using Cysharp.Threading.Internal;
 
 namespace Cysharp.Threading;
 
@@ -15,13 +15,19 @@ public sealed partial class LogicLooperPool
     /// <param name="targetFrameRate"></param>
     /// <param name="looperCount"></param>
     /// <param name="balancer"></param>
-    public static void InitializeSharedPool(int targetFrameRate, int looperCount = 0, ILogicLooperPoolBalancer? balancer = null)
+    /// <param name="looperFactory"></param>
+    public static void InitializeSharedPool(int targetFrameRate, int looperCount = 0, ILogicLooperPoolBalancer? balancer = null, ILogicLooperPoolLooperFactory? looperFactory = null)
     {
         if (looperCount == 0)
         {
             looperCount = Math.Max(1, Environment.ProcessorCount - 1);
         }
 
-        Shared = new LogicLooperPool(targetFrameRate, looperCount, balancer ?? RoundRobinLogicLooperPoolBalancer.Instance);
+        Shared = new LogicLooperPool(
+            targetFrameRate,
+            looperCount,
+            balancer ?? RoundRobinLogicLooperPoolBalancer.Instance,
+            looperFactory ?? DefaultLogicLooperPoolLooperFactory.Instance
+        );
     }
 }

--- a/src/LogicLooper/LogicLooperPool.cs
+++ b/src/LogicLooper/LogicLooperPool.cs
@@ -1,4 +1,4 @@
-using Cysharp.Threading.Internal;
+﻿using Cysharp.Threading.Internal;
 
 namespace Cysharp.Threading;
 
@@ -7,7 +7,7 @@ namespace Cysharp.Threading;
 /// </summary>
 public sealed partial class LogicLooperPool : ILogicLooperPool, IDisposable
 {
-    private readonly LogicLooper[] _loopers;
+    private readonly PooledLogicLooper[] _loopers;
     private readonly ILogicLooperPoolBalancer _balancer;
     private readonly CancellationTokenSource _shutdownTokenSource = new();
 
@@ -24,6 +24,7 @@ public sealed partial class LogicLooperPool : ILogicLooperPool, IDisposable
         : this(TimeSpan.FromMilliseconds(1000 / (double)targetFrameRate), looperCount, balancer)
     { }
 
+
     /// <summary>
     /// Initialize the looper pool with specified configurations.
     /// </summary>
@@ -31,13 +32,36 @@ public sealed partial class LogicLooperPool : ILogicLooperPool, IDisposable
     /// <param name="looperCount"></param>
     /// <param name="balancer"></param>
     public LogicLooperPool(TimeSpan targetFrameTime, int looperCount, ILogicLooperPoolBalancer balancer)
+        : this(targetFrameTime, looperCount, balancer, DefaultLogicLooperPoolLooperFactory.Instance)
+    {
+    }
+
+    /// <summary>
+    /// Initialize the looper pool with specified configurations.
+    /// </summary>
+    /// <param name="targetFrameRate"></param>
+    /// <param name="looperCount"></param>
+    /// <param name="balancer"></param>
+    /// <param name="looperFactory"></param>
+    public LogicLooperPool(int targetFrameRate, int looperCount, ILogicLooperPoolBalancer balancer, ILogicLooperPoolLooperFactory looperFactory)
+        : this(TimeSpan.FromMilliseconds(1000 / (double)targetFrameRate), looperCount, balancer, looperFactory)
+    { }
+
+    /// <summary>
+    /// Initialize the looper pool with specified configurations.
+    /// </summary>
+    /// <param name="targetFrameTime"></param>
+    /// <param name="looperCount"></param>
+    /// <param name="balancer"></param>
+    /// <param name="looperFactory"></param>
+    public LogicLooperPool(TimeSpan targetFrameTime, int looperCount, ILogicLooperPoolBalancer balancer, ILogicLooperPoolLooperFactory looperFactory)
     {
         if (looperCount <= 0) throw new ArgumentOutOfRangeException(nameof(looperCount), "LooperCount must be more than zero.");
 
-        _loopers = new LogicLooper[looperCount];
+        _loopers = new PooledLogicLooper[looperCount];
         for (var i = 0; i < looperCount; i++)
         {
-            _loopers[i] = new LogicLooper(targetFrameTime);
+            _loopers[i] = new PooledLogicLooper(looperFactory.Create(targetFrameTime));
         }
         _balancer = balancer ?? throw new ArgumentNullException(nameof(balancer));
     }
@@ -77,7 +101,7 @@ public sealed partial class LogicLooperPool : ILogicLooperPool, IDisposable
     /// <inheritdoc />
     public async Task ShutdownAsync(TimeSpan shutdownDelay)
     {
-        await Task.WhenAll(_loopers.Select(x => x.ShutdownAsync(shutdownDelay)));
+        await Task.WhenAll(_loopers.Select(x => x.WrappedLooper.ShutdownAsync(shutdownDelay)));
     }
 
     /// <inheritdoc />
@@ -90,12 +114,51 @@ public sealed partial class LogicLooperPool : ILogicLooperPool, IDisposable
         {
             try
             {
-                looper.Dispose();
+                looper.WrappedLooper.Dispose();
             }
             catch
             {
             }
         }
         _shutdownTokenSource.Cancel();
+    }
+
+    private class PooledLogicLooper : ILogicLooper
+    {
+        private readonly ILogicLooper _looper;
+
+        public ILogicLooper WrappedLooper => _looper;
+
+        public PooledLogicLooper(ILogicLooper looper)
+        {
+            _looper = looper ?? throw new ArgumentNullException(nameof(looper));
+        }
+
+        public int Id => _looper.Id;
+        public int ApproximatelyRunningActions => _looper.ApproximatelyRunningActions;
+        public TimeSpan LastProcessingDuration => _looper.LastProcessingDuration;
+        public double TargetFrameRate => _looper.TargetFrameRate;
+        public long CurrentFrame => _looper.CurrentFrame;
+        public Task RegisterActionAsync(LogicLooperActionDelegate loopAction)
+            => _looper.RegisterActionAsync(loopAction);
+        public Task RegisterActionAsync(LogicLooperActionDelegate loopAction, LooperActionOptions options)
+            => _looper.RegisterActionAsync(loopAction, options);
+        public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state)
+            => _looper.RegisterActionAsync(loopAction, state);
+        public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
+            => _looper.RegisterActionAsync(loopAction, state, options);
+        public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
+            => _looper.RegisterActionAsync(loopAction);
+        public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction, LooperActionOptions options)
+            => _looper.RegisterActionAsync(loopAction, options);
+        public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
+            => _looper.RegisterActionAsync(loopAction, state);
+        public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
+            => _looper.RegisterActionAsync(loopAction, state, options);
+
+        public Task ShutdownAsync(TimeSpan shutdownDelay)
+            => throw new NotSupportedException("PooledLogicLooper does not support ShutdownAsync. Use the LogicLooperPool to shutdown all loopers.");
+        public void Dispose()
+        {}
     }
 }

--- a/src/LogicLooper/RoundRobinLogicLooperPoolBalancer.cs
+++ b/src/LogicLooper/RoundRobinLogicLooperPoolBalancer.cs
@@ -1,4 +1,4 @@
-namespace Cysharp.Threading;
+﻿namespace Cysharp.Threading;
 
 public class RoundRobinLogicLooperPoolBalancer : ILogicLooperPoolBalancer
 {
@@ -9,7 +9,7 @@ public class RoundRobinLogicLooperPoolBalancer : ILogicLooperPoolBalancer
     protected RoundRobinLogicLooperPoolBalancer()
     { }
 
-    public LogicLooper GetPooledLooper(LogicLooper[] pooledLoopers)
+    public ILogicLooper GetPooledLooper(ILogicLooper[] pooledLoopers)
     {
         return pooledLoopers[Interlocked.Increment(ref _index) % pooledLoopers.Length];
     }

--- a/test/LogicLooper.Test/LogicLooperPoolTest.cs
+++ b/test/LogicLooper.Test/LogicLooperPoolTest.cs
@@ -1,4 +1,4 @@
-using Cysharp.Threading;
+﻿using Cysharp.Threading;
 
 namespace LogicLooper.Test;
 
@@ -55,12 +55,172 @@ public class LogicLooperPoolTest
         Assert.Equal(pool.Loopers[0], pool.GetLooper());
     }
 
+    [Fact]
+    public void PooledLogicLooper_Dispose_Noop()
+    {
+        var looperFactory = new FakeLogicLooperPoolLooperFactory();
+        using var pool = new LogicLooperPool(60, 4, RoundRobinLogicLooperPoolBalancer.Instance, looperFactory);
+        var pooled1 = pool.GetLooper();
+        var pooled2 = pool.GetLooper();
+
+        Assert.Equal(4, looperFactory.CreatedLoopers.Count);
+        Assert.False(looperFactory.CreatedLoopers[0].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[1].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[2].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[3].IsDisposed);
+
+        pooled1.Dispose();
+        pooled2.Dispose();
+
+        Assert.False(looperFactory.CreatedLoopers[0].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[1].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[2].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[3].IsDisposed);
+    }
+
+    [Fact]
+    public void PooledLogicLooper_DisposeFromLooperPool()
+    {
+        var looperFactory = new FakeLogicLooperPoolLooperFactory();
+        var pool = new LogicLooperPool(60, 4, RoundRobinLogicLooperPoolBalancer.Instance, looperFactory);
+
+        Assert.Equal(4, looperFactory.CreatedLoopers.Count);
+        Assert.False(looperFactory.CreatedLoopers[0].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[1].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[2].IsDisposed);
+        Assert.False(looperFactory.CreatedLoopers[3].IsDisposed);
+
+        pool.Dispose();
+
+        Assert.True(looperFactory.CreatedLoopers[0].IsDisposed);
+        Assert.True(looperFactory.CreatedLoopers[1].IsDisposed);
+        Assert.True(looperFactory.CreatedLoopers[2].IsDisposed);
+        Assert.True(looperFactory.CreatedLoopers[3].IsDisposed);
+    }
+
+    [Fact]
+    public async Task PooledLogicLooper_ShutdownAsync_NotSupported()
+    {
+        var looperFactory = new FakeLogicLooperPoolLooperFactory();
+        using var pool = new LogicLooperPool(60, 4, RoundRobinLogicLooperPoolBalancer.Instance, looperFactory);
+        var pooled1 = pool.GetLooper();
+        var pooled2 = pool.GetLooper();
+
+        Assert.Equal(4, looperFactory.CreatedLoopers.Count);
+        Assert.False(looperFactory.CreatedLoopers[0].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[1].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[2].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[3].IsShutdownRequested);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => pooled1.ShutdownAsync(TimeSpan.FromSeconds(1)));
+        await Assert.ThrowsAsync<NotSupportedException>(() => pooled2.ShutdownAsync(TimeSpan.FromSeconds(1)));
+        Assert.False(looperFactory.CreatedLoopers[0].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[1].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[2].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[3].IsShutdownRequested);
+    }
+
+    [Fact]
+    public async Task PooledLogicLooper_ShutdownAsyncFromLooperPool()
+    {
+        var looperFactory = new FakeLogicLooperPoolLooperFactory();
+        using var pool = new LogicLooperPool(60, 4, RoundRobinLogicLooperPoolBalancer.Instance, looperFactory);
+        var pooled1 = pool.GetLooper();
+        var pooled2 = pool.GetLooper();
+
+        Assert.Equal(4, looperFactory.CreatedLoopers.Count);
+        Assert.False(looperFactory.CreatedLoopers[0].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[1].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[2].IsShutdownRequested);
+        Assert.False(looperFactory.CreatedLoopers[3].IsShutdownRequested);
+
+        await pool.ShutdownAsync(TimeSpan.FromSeconds(1));
+        Assert.True(looperFactory.CreatedLoopers[0].IsShutdownRequested);
+        Assert.True(looperFactory.CreatedLoopers[1].IsShutdownRequested);
+        Assert.True(looperFactory.CreatedLoopers[2].IsShutdownRequested);
+        Assert.True(looperFactory.CreatedLoopers[3].IsShutdownRequested);
+    }
+
     class FakeSequentialLogicLooperPoolBalancer : ILogicLooperPoolBalancer
     {
         private int _count;
-        public Cysharp.Threading.LogicLooper GetPooledLooper(Cysharp.Threading.LogicLooper[] pooledLoopers)
+        public Cysharp.Threading.ILogicLooper GetPooledLooper(Cysharp.Threading.ILogicLooper[] pooledLoopers)
         {
             return pooledLoopers[_count++ % pooledLoopers.Length];
+        }
+    }
+
+    class FakeLogicLooperPoolLooperFactory : ILogicLooperPoolLooperFactory
+    {
+        public List<LogicLooper> CreatedLoopers { get; } = new();
+
+        public ILogicLooper Create(TimeSpan targetFrameTime)
+        {
+            var looper = new LogicLooper();
+            CreatedLoopers.Add(looper);
+            return looper;
+        }
+
+        public class LogicLooper : ILogicLooper
+        {
+            public bool IsDisposed { get; set; }
+            public bool IsShutdownRequested { get; set; }
+
+            public void Dispose()
+            {
+                IsDisposed = true;
+            }
+
+            public int Id { get; }
+            public int ApproximatelyRunningActions { get; }
+            public TimeSpan LastProcessingDuration { get; }
+            public double TargetFrameRate { get; }
+            public long CurrentFrame { get; }
+            public Task RegisterActionAsync(LogicLooperActionDelegate loopAction)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task RegisterActionAsync(LogicLooperActionDelegate loopAction, LooperActionOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task RegisterActionAsync<TState>(LogicLooperActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task RegisterActionAsync(LogicLooperAsyncActionDelegate loopAction, LooperActionOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task RegisterActionAsync<TState>(LogicLooperAsyncActionWithStateDelegate<TState> loopAction, TState state, LooperActionOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task ShutdownAsync(TimeSpan shutdownDelay)
+            {
+                IsShutdownRequested = true;
+                return Task.CompletedTask;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR change prevents LogicLooper instances obtained from LogicLooperPool from being disposed or shut down.

Directly stopping a LogicLooper obtained from the pool may leave an inactive instance in the pool, which can lead to unintended hangs.

- Updated ILogicLooperPoolBalancer to use ILogicLooper[] and added ILogicLooperPoolLooperFactory for creating looper instances.
- Modified LogicLooperPool to utilize PooledLogicLooper, enhancing encapsulation and factory integration.
- Updated ShutdownAsync for proper shutdown behavior and added tests for PooledLogicLooper functionality.

These changes improve flexibility and testability in the logic looper pool system.