### PR TITLE
feat: replace docfx build from container to docfx command

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.78.3",
+      "commands": [
+        "docfx"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -19,14 +19,11 @@ jobs:
         with:
           repository: Cysharp/DocfxTemplate
           path: docs/_DocfxTemplate
-      - uses: Kirbyrawr/docfx-action@db9a22c8fe1e8693a2a21be54cb0b87dfaa72cc4
-        name: Docfx metadata
-        with:
-          args: metadata docs/docfx.json
-      - uses: Kirbyrawr/docfx-action@db9a22c8fe1e8693a2a21be54cb0b87dfaa72cc4
-        name: Docfx build
-        with:
-          args: build docs/docfx.json
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+      - name: Docfx metadata
+        run: dotnet docfx metadata docs/docfx.json
+      - name: Docfx build
+        run: dotnet docfx build docs/docfx.json
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:


### PR DESCRIPTION
## Description

Current docfx build by container failed, https://github.com/Cysharp/LogicLooper/actions/runs/17065215978/job/48380937955 , and won't recover by user-side. Let's change build flow to [docfx dotnet tool](https://github.com/dotnet/docfx).

Confirmed local serve is as same as current deployed one.